### PR TITLE
87/t/STORY-2792_backdraft_detail_reports: Fixes bug in dataTables

### DIFF
--- a/dist/backdraft.js
+++ b/dist/backdraft.js
@@ -1422,13 +1422,13 @@ _.extend(Plugin.factory, {
         $(this).contents().appendTo(nDiv);
         this.appendChild(nDiv);
         // handle clicking on div as sorting
-        $('.DataTables_sort_wrapper', this).on("click", function(event) {
+        $(this).on("click", function(event) {
           if (self.lock("sort")) {
             event.stopImmediatePropagation();
           }
         });
         // default sort handler for column with index
-        self.dataTable.fnSortListener($('.DataTables_sort_wrapper', this), index);
+        self.dataTable.fnSortListener($(this), index);
       });
     },
 

--- a/dist/backdraft.js
+++ b/dist/backdraft.js
@@ -1457,7 +1457,7 @@ _.extend(Plugin.factory, {
       table.dataTable.find("thead th").each(function (index) {
         // here we use the text in the header to get the column config by title
         // there isn't a better way to do this currently
-        var title = this.outerText;
+        var title = this.textContent;
         var col = cg.columnConfigByTitle.attributes[title];
 
         if (col) {

--- a/dist/backdraft.js
+++ b/dist/backdraft.js
@@ -1457,7 +1457,6 @@ _.extend(Plugin.factory, {
       table.dataTable.find("thead th").each(function (index) {
         // here we use the text in the header to get the column config by title
         // there isn't a better way to do this currently
-        debugger;
         var title = this.textContent || this.innerText;
         var col = cg.columnConfigByTitle.attributes[title];
 

--- a/dist/backdraft.js
+++ b/dist/backdraft.js
@@ -1457,7 +1457,8 @@ _.extend(Plugin.factory, {
       table.dataTable.find("thead th").each(function (index) {
         // here we use the text in the header to get the column config by title
         // there isn't a better way to do this currently
-        var title = this.textContent;
+        debugger;
+        var title = this.textContent || this.innerText;
         var col = cg.columnConfigByTitle.attributes[title];
 
         if (col) {

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -377,7 +377,8 @@ var LocalDataTable = (function() {
       table.dataTable.find("thead th").each(function (index) {
         // here we use the text in the header to get the column config by title
         // there isn't a better way to do this currently
-        var title = this.textContent;
+        debugger;
+        var title = this.textContent || this.innerText;
         var col = cg.columnConfigByTitle.attributes[title];
 
         if (col) {

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -377,7 +377,7 @@ var LocalDataTable = (function() {
       table.dataTable.find("thead th").each(function (index) {
         // here we use the text in the header to get the column config by title
         // there isn't a better way to do this currently
-        var title = this.outerText;
+        var title = this.textContent;
         var col = cg.columnConfigByTitle.attributes[title];
 
         if (col) {

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -342,13 +342,13 @@ var LocalDataTable = (function() {
         $(this).contents().appendTo(nDiv);
         this.appendChild(nDiv);
         // handle clicking on div as sorting
-        $('.DataTables_sort_wrapper', this).on("click", function(event) {
+        $(this).on("click", function(event) {
           if (self.lock("sort")) {
             event.stopImmediatePropagation();
           }
         });
         // default sort handler for column with index
-        self.dataTable.fnSortListener($('.DataTables_sort_wrapper', this), index);
+        self.dataTable.fnSortListener($(this), index);
       });
     },
 

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -377,7 +377,6 @@ var LocalDataTable = (function() {
       table.dataTable.find("thead th").each(function (index) {
         // here we use the text in the header to get the column config by title
         // there isn't a better way to do this currently
-        debugger;
         var title = this.textContent || this.innerText;
         var col = cg.columnConfigByTitle.attributes[title];
 


### PR DESCRIPTION
outerText method doesn't work in firefox, bug was causing dataTables to skip the rendering of filters. Replaced with textContent method which is functionally equivalent and works in firefox.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/invoca/backdraft/33)
<!-- Reviewable:end -->
