### PR TITLE
UX :: column resize support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/* binary

--- a/dist/backdraft.js
+++ b/dist/backdraft.js
@@ -1246,13 +1246,17 @@ _.extend(Plugin.factory, {
 
     _enableReorderableColumns: function() {
       var self = this;
-      new $.fn.dataTable.ColReorder(this.dataTable, {
+      self._colReorder = new $.fn.dataTable.ColReorder(this.dataTable, {
         fnReorderCallback: function(fromIndex, toIndex) {
           // notify that columns have been externally rearranged
           self._columnManager.columnsSwapped(fromIndex, toIndex);
           // pass event up
           self._onColumnReorder();
-        }
+        },
+        bAddFixed: false,
+        bResizeTableWrapper: false,
+        allowHeaderDoubleClick: false,
+        allowResize: self.resizableColumns
       });
     },
 
@@ -1263,11 +1267,11 @@ _.extend(Plugin.factory, {
     _changeColumnOrder: function(order) {
       var columnsOrig = _.clone(this.dataTable.fnSettings().aoColumns);
       if (_.isArray(order)) {
-        this.dataTable.fnSettings()._colReorder.fnOrder(order);
+        this._colReorder.fnOrder(order);
       } else if (_.has(order, 'reset') && order.reset) {
-        this.dataTable.fnSettings()._colReorder.fnReset();
+        this._colReorder.fnReset();
       } else {
-        return this.dataTable.fnSettings()._colReorder.fnOrder();
+        return this._colReorder.fnOrder();
       }
 
       // restore columnsConfig order to match the underlying order from dataTable
@@ -1306,6 +1310,7 @@ _.extend(Plugin.factory, {
         filteringEnabled: false,
         layout : "<'row'<'col-xs-6'l><'col-xs-6'f>r>t<'row'<'col-xs-6'i><'col-xs-6'p>>",
         reorderableColumns: true,
+        resizableColumns: false,
         objectName: {
           singular: "row",
           plural: "rows"
@@ -2002,30 +2007,35 @@ $.extend( $.fn.dataTableExt.oPagination, {
   }
 } );
 
-    /*! ColReorder 1.1.3-dev
- * ©2010-2014 SpryMedia Ltd - datatables.net/license
+    /*
+ * File:        ColReorderWithResize-1.1.0-dev2.js
+ *
+ * Based on (with minor changes):
+ * https://github.com/jhubble/ColReorderWithResize/blob/0aebd15b89debe9d52efe5c6b29c07703c025e3d/media/js/ColReorderWithResize.js
+ *
+ * Version:     1.1.0-dev2 (based on commit 2a6de4e884 done on Feb 22, 2013)
+ * CVS:         $Id$
+ * Description: Allow columns to be reordered in a DataTable
+ * Author:      Allan Jardine (www.sprymedia.co.uk)
+ * Created:     Wed Sep 15 18:23:29 BST 2010
+ * Modified:    2013 feb 2013 by nlz242
+ * Language:    Javascript
+ * License:     GPL v2 or BSD 3 point style
+ * Project:     DataTables
+ * Contact:     www.sprymedia.co.uk/contact
+ *
+ * Copyright 2010-2013 Allan Jardine, all rights reserved.
+ *
+ * This source file is free software, under either the GPL v2 license or a
+ * BSD style license, available at:
+ *   http://datatables.net/license_gpl2
+ *   http://datatables.net/license_bsd
+ *
+ * Minor bug fixes by Jeremy Hubble @jeremyhubble
  */
 
-/**
- * @summary     ColReorder
- * @description Provide the ability to reorder columns in a DataTable
- * @version     1.1.3-dev
- * @file        dataTables.colReorder.js
- * @author      SpryMedia Ltd (www.sprymedia.co.uk)
- * @contact     www.sprymedia.co.uk/contact
- * @copyright   Copyright 2010-2014 SpryMedia Ltd.
- *
- * This source file is free software, available under the following license:
- *   MIT license - http://datatables.net/license/mit
- *
- * This source file is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the license files for details.
- *
- * For details please refer to: http://www.datatables.net
- */
 
-(function(window, document, undefined) {
+(function ($, window, document) {
 
 
   /**
@@ -2035,12 +2045,10 @@ $.extend( $.fn.dataTableExt.oPagination, {
    *  @param   array aIn Array to switch around
    *  @returns array
    */
-  function fnInvertKeyValues( aIn )
-  {
-    var aRet=[];
-    for ( var i=0, iLen=aIn.length ; i<iLen ; i++ )
-    {
-      aRet[ aIn[i] ] = i;
+  function fnInvertKeyValues(aIn) {
+    var aRet = [];
+    for (var i = 0, iLen = aIn.length; i < iLen; i++) {
+      aRet[aIn[i]] = i;
     }
     return aRet;
   }
@@ -2054,10 +2062,9 @@ $.extend( $.fn.dataTableExt.oPagination, {
    *  @param   int iTo Insert point
    *  @returns void
    */
-  function fnArraySwitch( aArray, iFrom, iTo )
-  {
-    var mStore = aArray.splice( iFrom, 1 )[0];
-    aArray.splice( iTo, 0, mStore );
+  function fnArraySwitch(aArray, iFrom, iTo) {
+    var mStore = aArray.splice(iFrom, 1)[0];
+    aArray.splice(iTo, 0, mStore);
   }
 
 
@@ -2070,32 +2077,32 @@ $.extend( $.fn.dataTableExt.oPagination, {
    *  @param   int Point to element the element to (before this point), can be null for append
    *  @returns void
    */
-  function fnDomSwitch( nParent, iFrom, iTo )
-  {
+  function fnDomSwitch(nParent, iFrom, iTo) {
     var anTags = [];
-    for ( var i=0, iLen=nParent.childNodes.length ; i<iLen ; i++ )
-    {
-      if ( nParent.childNodes[i].nodeType == 1 )
-      {
-        anTags.push( nParent.childNodes[i] );
+    for (var i = 0, iLen = nParent.childNodes.length; i < iLen; i++) {
+      if (nParent.childNodes[i].nodeType == 1) {
+        anTags.push(nParent.childNodes[i]);
       }
     }
-    var nStore = anTags[ iFrom ];
+    var nStore = anTags[iFrom];
 
-    if ( iTo !== null )
-    {
-      nParent.insertBefore( nStore, anTags[iTo] );
+    if (iTo !== null) {
+      nParent.insertBefore(nStore, anTags[iTo]);
     }
-    else
-    {
-      nParent.appendChild( nStore );
+    else {
+      nParent.appendChild(nStore);
     }
   }
 
 
 
-  var factory = function( $, DataTable ) {
-  "use strict";
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * DataTables plug-in API functions
+   *
+   * This are required by ColReorder in order to perform the tasks required, and also keep this
+   * code portable, to be used for other column reordering projects with DataTables, if needed.
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
 
   /**
    * Plug-in for DataTables which will reorder the internal column structure by taking the column
@@ -2106,41 +2113,22 @@ $.extend( $.fn.dataTableExt.oPagination, {
    *  @param   int iTo and insert it into this point
    *  @returns void
    */
-  $.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo )
-  {
-    var v110 = $.fn.dataTable.Api ? true : false;
-    var i, iLen, j, jLen, iCols=oSettings.aoColumns.length, nTrs, oCol;
-    var attrMap = function ( obj, prop, mapping ) {
-      if ( ! obj[ prop ] ) {
-        return;
-      }
-
-      var a = obj[ prop ].split('.');
-      var num = a.shift();
-
-      if ( isNaN( num*1 ) ) {
-        return;
-      }
-
-      obj[ prop ] = mapping[ num*1 ]+'.'+a.join('.');
-    };
+  $.fn.dataTableExt.oApi.fnColReorder = function (oSettings, iFrom, iTo) {
+    var i, iLen, j, jLen, iCols = oSettings.aoColumns.length, nTrs, oCol;
 
     /* Sanity check in the input */
-    if ( iFrom == iTo )
-    {
+    if (iFrom == iTo) {
       /* Pointless reorder */
       return;
     }
 
-    if ( iFrom < 0 || iFrom >= iCols )
-    {
-      this.oApi._fnLog( oSettings, 1, "ColReorder 'from' index is out of bounds: "+iFrom );
+    if (iFrom < 0 || iFrom >= iCols) {
+      this.oApi._fnLog(oSettings, 1, "ColReorder 'from' index is out of bounds: " + iFrom);
       return;
     }
 
-    if ( iTo < 0 || iTo >= iCols )
-    {
-      this.oApi._fnLog( oSettings, 1, "ColReorder 'to' index is out of bounds: "+iTo );
+    if (iTo < 0 || iTo >= iCols) {
+      this.oApi._fnLog(oSettings, 1, "ColReorder 'to' index is out of bounds: " + iTo);
       return;
     }
 
@@ -2148,74 +2136,33 @@ $.extend( $.fn.dataTableExt.oPagination, {
      * Calculate the new column array index, so we have a mapping between the old and new
      */
     var aiMapping = [];
-    for ( i=0, iLen=iCols ; i<iLen ; i++ )
-    {
+    for (i = 0, iLen = iCols; i < iLen; i++) {
       aiMapping[i] = i;
     }
-    fnArraySwitch( aiMapping, iFrom, iTo );
-    var aiInvertMapping = fnInvertKeyValues( aiMapping );
+    fnArraySwitch(aiMapping, iFrom, iTo);
+    var aiInvertMapping = fnInvertKeyValues(aiMapping);
 
 
     /*
      * Convert all internal indexing to the new column order indexes
      */
     /* Sorting */
-    for ( i=0, iLen=oSettings.aaSorting.length ; i<iLen ; i++ )
-    {
-      oSettings.aaSorting[i][0] = aiInvertMapping[ oSettings.aaSorting[i][0] ];
+    for (i = 0, iLen = oSettings.aaSorting.length; i < iLen; i++) {
+      oSettings.aaSorting[i][0] = aiInvertMapping[oSettings.aaSorting[i][0]];
     }
 
     /* Fixed sorting */
-    if ( oSettings.aaSortingFixed !== null )
-    {
-      for ( i=0, iLen=oSettings.aaSortingFixed.length ; i<iLen ; i++ )
-      {
-        oSettings.aaSortingFixed[i][0] = aiInvertMapping[ oSettings.aaSortingFixed[i][0] ];
+    if (oSettings.aaSortingFixed !== null) {
+      for (i = 0, iLen = oSettings.aaSortingFixed.length; i < iLen; i++) {
+        oSettings.aaSortingFixed[i][0] = aiInvertMapping[oSettings.aaSortingFixed[i][0]];
       }
     }
 
     /* Data column sorting (the column which the sort for a given column should take place on) */
-    for ( i=0, iLen=iCols ; i<iLen ; i++ )
-    {
+    for (i = 0, iLen = iCols; i < iLen; i++) {
       oCol = oSettings.aoColumns[i];
-      for ( j=0, jLen=oCol.aDataSort.length ; j<jLen ; j++ )
-      {
-        oCol.aDataSort[j] = aiInvertMapping[ oCol.aDataSort[j] ];
-      }
-
-      // Update the column indexes
-      if ( v110 ) {
-        oCol.idx = aiInvertMapping[ oCol.idx ];
-      }
-    }
-
-    if ( v110 ) {
-      // Update 1.10 optimised sort class removal variable
-      $.each( oSettings.aLastSort, function (i, val) {
-        oSettings.aLastSort[i].src = aiInvertMapping[ val.src ];
-      } );
-    }
-
-    /* Update the Get and Set functions for each column */
-    for ( i=0, iLen=iCols ; i<iLen ; i++ )
-    {
-      oCol = oSettings.aoColumns[i];
-
-      if ( typeof oCol.mData == 'number' ) {
-        oCol.mData = aiInvertMapping[ oCol.mData ];
-
-        // regenerate the get / set functions
-        oSettings.oApi._fnColumnOptions( oSettings, i, {} );
-      }
-      else if ( $.isPlainObject( oCol.mData ) ) {
-        // HTML5 data sourced
-        attrMap( oCol.mData, '_',      aiInvertMapping );
-        attrMap( oCol.mData, 'filter', aiInvertMapping );
-        attrMap( oCol.mData, 'sort',   aiInvertMapping );
-        attrMap( oCol.mData, 'type',   aiInvertMapping );
-
-        // regenerate the get / set functions
-        oSettings.oApi._fnColumnOptions( oSettings, i, {} );
+      for (j = 0, jLen = oCol.aDataSort.length; j < jLen; j++) {
+        oCol.aDataSort[j] = aiInvertMapping[oCol.aDataSort[j]];
       }
     }
 
@@ -2223,124 +2170,93 @@ $.extend( $.fn.dataTableExt.oPagination, {
     /*
      * Move the DOM elements
      */
-    if ( oSettings.aoColumns[iFrom].bVisible )
-    {
+    if (oSettings.aoColumns[iFrom].bVisible) {
       /* Calculate the current visible index and the point to insert the node before. The insert
        * before needs to take into account that there might not be an element to insert before,
        * in which case it will be null, and an appendChild should be used
        */
-      var iVisibleIndex = this.oApi._fnColumnIndexToVisible( oSettings, iFrom );
+      var iVisibleIndex = this.oApi._fnColumnIndexToVisible(oSettings, iFrom);
       var iInsertBeforeIndex = null;
 
       i = iTo < iFrom ? iTo : iTo + 1;
-      while ( iInsertBeforeIndex === null && i < iCols )
-      {
-        iInsertBeforeIndex = this.oApi._fnColumnIndexToVisible( oSettings, i );
+      while (iInsertBeforeIndex === null && i < iCols) {
+        iInsertBeforeIndex = this.oApi._fnColumnIndexToVisible(oSettings, i);
         i++;
       }
 
       /* Header */
       nTrs = oSettings.nTHead.getElementsByTagName('tr');
-      for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
-      {
-        fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+      for (i = 0, iLen = nTrs.length; i < iLen; i++) {
+        fnDomSwitch(nTrs[i], iVisibleIndex, iInsertBeforeIndex);
       }
 
       /* Footer */
-      if ( oSettings.nTFoot !== null )
-      {
+      if (oSettings.nTFoot !== null) {
         nTrs = oSettings.nTFoot.getElementsByTagName('tr');
-        for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
-        {
-          fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+        for (i = 0, iLen = nTrs.length; i < iLen; i++) {
+          fnDomSwitch(nTrs[i], iVisibleIndex, iInsertBeforeIndex);
         }
       }
 
       /* Body */
-      for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
-      {
-        if ( oSettings.aoData[i].nTr !== null )
-        {
-          fnDomSwitch( oSettings.aoData[i].nTr, iVisibleIndex, iInsertBeforeIndex );
+      for (i = 0, iLen = oSettings.aoData.length; i < iLen; i++) {
+        if (oSettings.aoData[i].nTr !== null) {
+          fnDomSwitch(oSettings.aoData[i].nTr, iVisibleIndex, iInsertBeforeIndex);
         }
       }
     }
+
 
     /*
      * Move the internal array elements
      */
     /* Columns */
-    fnArraySwitch( oSettings.aoColumns, iFrom, iTo );
+    fnArraySwitch(oSettings.aoColumns, iFrom, iTo);
 
     /* Search columns */
-    fnArraySwitch( oSettings.aoPreSearchCols, iFrom, iTo );
+    fnArraySwitch(oSettings.aoPreSearchCols, iFrom, iTo);
 
     /* Array array - internal data anodes cache */
-    for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
-    {
-      var data = oSettings.aoData[i];
-
-      if ( v110 ) {
-        // DataTables 1.10+
-        if ( data.anCells ) {
-          fnArraySwitch( data.anCells, iFrom, iTo );
-        }
-
-        // For DOM sourced data, the invalidate will reread the cell into
-        // the data array, but for data sources as an array, they need to
-        // be flipped
-        if ( data.src !== 'dom' && $.isArray( data._aData ) ) {
-          fnArraySwitch( data._aData, iFrom, iTo );
-        }
-      }
-      else {
-        // DataTables 1.9-
-        if ( $.isArray( data._aData ) ) {
-          fnArraySwitch( data._aData, iFrom, iTo );
-        }
-        fnArraySwitch( data._anHidden, iFrom, iTo );
-      }
+    for (i = 0, iLen = oSettings.aoData.length; i < iLen; i++) {
+      fnArraySwitch(oSettings.aoData[i]._anHidden, iFrom, iTo);
     }
 
     /* Reposition the header elements in the header layout array */
-    for ( i=0, iLen=oSettings.aoHeader.length ; i<iLen ; i++ )
-    {
-      fnArraySwitch( oSettings.aoHeader[i], iFrom, iTo );
+    for (i = 0, iLen = oSettings.aoHeader.length; i < iLen; i++) {
+      fnArraySwitch(oSettings.aoHeader[i], iFrom, iTo);
     }
 
-    if ( oSettings.aoFooter !== null )
-    {
-      for ( i=0, iLen=oSettings.aoFooter.length ; i<iLen ; i++ )
-      {
-        fnArraySwitch( oSettings.aoFooter[i], iFrom, iTo );
+    if (oSettings.aoFooter !== null) {
+      for (i = 0, iLen = oSettings.aoFooter.length; i < iLen; i++) {
+        fnArraySwitch(oSettings.aoFooter[i], iFrom, iTo);
       }
     }
 
-    // In 1.10 we need to invalidate row cached data for sorting, filtering etc
-    if ( v110 ) {
-      var api = new $.fn.dataTable.Api( oSettings );
-      api.rows().invalidate();
-    }
 
     /*
      * Update DataTables' event handlers
      */
 
     /* Sort listener */
-    for ( i=0, iLen=iCols ; i<iLen ; i++ )
-    {
-      $(oSettings.aoColumns[i].nTh).off('click.DT');
-      this.oApi._fnSortAttachListener( oSettings, oSettings.aoColumns[i].nTh, i );
+    for (i = 0, iLen = iCols; i < iLen; i++) {
+      $(oSettings.aoColumns[i].nTh).off('click');
+      this.oApi._fnSortAttachListener(oSettings, oSettings.aoColumns[i].nTh, i);
     }
 
 
     /* Fire an event so other plug-ins can update */
-    $(oSettings.oInstance).trigger( 'column-reorder', [ oSettings, {
+    $(oSettings.oInstance).trigger('column-reorder', [oSettings, {
       "iFrom": iFrom,
       "iTo": iTo,
       "aiInvertMapping": aiInvertMapping
-    } ] );
+    }]);
+
+    if (typeof oSettings.oInstance._oPluginFixedHeader != 'undefined') {
+      oSettings.oInstance._oPluginFixedHeader.fnUpdate();
+    }
   };
+
+
 
 
   /**
@@ -2350,33 +2266,29 @@ $.extend( $.fn.dataTableExt.oPagination, {
    * @param {object} dt DataTables settings object
    * @param {object} opts ColReorder options
    */
-  var ColReorder = function( dt, opts )
-  {
+  var ColReorder = function (dt, opts) {
     var oDTSettings;
 
-    if ( $.fn.dataTable.Api ) {
-      oDTSettings = new $.fn.dataTable.Api( dt ).settings()[0];
-    }
-    // 1.9 compatibility
-    else if ( dt.fnSettings ) {
+    // @todo - This should really be a static method offered by DataTables
+    if (dt.fnSettings) {
       // DataTables object, convert to the settings object
       oDTSettings = dt.fnSettings();
     }
-    else if ( typeof dt === 'string' ) {
+    else if (typeof dt === 'string') {
       // jQuery selector
-      if ( $.fn.dataTable.fnIsDataTable( $(dt)[0] ) ) {
+      if ($.fn.dataTable.fnIsDataTable($(dt)[0])) {
         oDTSettings = $(dt).eq(0).dataTable().fnSettings();
       }
     }
-    else if ( dt.nodeName && dt.nodeName.toLowerCase() === 'table' ) {
+    else if (dt.nodeName && dt.nodeName.toLowerCase() === 'table') {
       // Table node
-      if ( $.fn.dataTable.fnIsDataTable( dt.nodeName ) ) {
+      if ($.fn.dataTable.fnIsDataTable(dt.nodeName)) {
         oDTSettings = $(dt.nodeName).dataTable().fnSettings();
       }
     }
-    else if ( dt instanceof jQuery ) {
+    else if (dt instanceof jQuery) {
       // jQuery object
-      if ( $.fn.dataTable.fnIsDataTable( dt[0] ) ) {
+      if ($.fn.dataTable.fnIsDataTable(dt[0])) {
         oDTSettings = dt.eq(0).dataTable().fnSettings();
       }
     }
@@ -2385,18 +2297,16 @@ $.extend( $.fn.dataTableExt.oPagination, {
       oDTSettings = dt;
     }
 
-    // Ensure that we can't initialise on the same table twice
-    if ( oDTSettings._colReorder ) {
-      throw "ColReorder already initialised on table #"+oDTSettings.nTable.id;
-    }
+    if (this instanceof ColReorder === false) {
+      // Get a ColReorder instance - effectively a static method
+      for (var i = 0, iLen = ColReorder.aoInstances.length; i < iLen; i++) {
+        if (ColReorder.aoInstances[i].s.dt == oDTSettings) {
+          return ColReorder.aoInstances[i];
+        }
+      }
 
-    // Convert from camelCase to Hungarian, just as DataTables does
-    var camelToHungarian = $.fn.dataTable.camelToHungarian;
-    if ( camelToHungarian ) {
-      camelToHungarian( ColReorder.defaults, ColReorder.defaults, true );
-      camelToHungarian( ColReorder.defaults, opts || {} );
+      return null;
     }
-
 
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
      * Public class variables
@@ -2420,7 +2330,43 @@ $.extend( $.fn.dataTableExt.oPagination, {
        *  @type     object
        *  @default  {}
        */
-      "init": $.extend( true, {}, ColReorder.defaults, opts ),
+      "init": $.extend(true, {}, ColReorder.defaults, opts),
+
+      /**
+       * Allow Reorder functionnality
+       *  @property allowReorder
+       *  @type     boolean
+       *  @default  true
+       */
+      "allowReorder": true,
+
+      /**
+       * Expand or collapse columns based on header double clicks
+       *  @property allowHeaderDoubleClick
+       *  @type     boolean
+       *  @default  true
+       */
+      "allowHeaderDoubleClick": true,
+
+      /**
+       * Expand or collapse columns based on header double clicks
+       * If set to true will use the default menu
+       * - If set to false, no context menu will be used
+       * - If set to true, the default context menu will be used
+       * - If given a function, that function will be called
+       *  @property headerContextMenu
+       *  @type     boolean/function
+       *  @default  true
+       */
+      "headerContextMenu": true,
+
+      /**
+       * Allow Resize functionnality
+       *  @property allowResize
+       *  @type     boolean
+       *  @default  true
+       */
+      "allowResize": true,
 
       /**
        * Number of columns to fix (not allow to be reordered)
@@ -2468,7 +2414,56 @@ $.extend( $.fn.dataTableExt.oPagination, {
        *  @type     array
        *  @default  []
        */
-      "aoTargets": []
+      "aoTargets": [],
+
+      /**
+       * Minimum width for columns (in pixels)
+       * Default is 10. If set to 0, columns can be resized to nothingness.
+       * @property minResizeWidth
+       * @type     integer
+       * @default  10
+       */
+      "minResizeWidth": 10,
+
+      /**
+       * Resize the table when columns are resized
+       * @property bResizeTable
+       * @type     boolean
+       * @default  true
+       */
+      "bResizeTable": true,
+
+      /**
+       * Resize the table when columns are resized
+       * @property bResizeTable
+       * @type     boolean
+       * @default  false
+       */
+      "bResizeTableWrapper": true,
+
+      /**
+       * Callback called after each time the table is resized
+       * This could be multiple times on one mouse move.
+       * useful for resizing a containing element.
+       * Passed the table element, new size, and the size change
+       * @property fnResizeTableCallback
+       * @type     function
+       * @default  function(table, newSize, sizeChange) {}
+       */
+      "fnResizeTableCallback": function(){},
+
+      /**
+       * Add table-layout:fixed css to the table
+       * This header is required for column resize to function properly
+       * However, in some cases, you may want to do additional processing, and thus not set the header
+       * (For example, you may want the headers to be layed out normally, and then fix the table
+       *  after the headers are allocated their full space. In this case, you can manually add the css
+       *  in fnHeaderCallback and set bAddFixed to false here)
+       * @property bAddFixed
+       * @type     boolean
+       * @default  true
+       */
+      "bAddFixed": true
     };
 
 
@@ -2485,6 +2480,14 @@ $.extend( $.fn.dataTableExt.oPagination, {
       "drag": null,
 
       /**
+       * Resizing a column
+       *  @property drag
+       *  @type     element
+       *  @default  null
+       */
+      "resize": null,
+
+      /**
        * The insert cursor
        *  @property pointer
        *  @type     element
@@ -2493,15 +2496,37 @@ $.extend( $.fn.dataTableExt.oPagination, {
       "pointer": null
     };
 
+    this.table_size = -1;
 
     /* Constructor logic */
-    this.s.dt = oDTSettings;
-    this.s.dt._colReorder = this;
+    this.s.dt = oDTSettings.oInstance.fnSettings();
     this._fnConstruct();
 
     /* Add destroy callback */
     oDTSettings.oApi._fnCallbackReg(oDTSettings, 'aoDestroyCallback', $.proxy(this._fnDestroy, this), 'ColReorder');
 
+    /* Store the instance for later use */
+    ColReorder.aoInstances.push(this);
+
+
+    if (this.s.bResizeTableWrapper) {
+      $(this.s.dt.nTableWrapper).width($(this.s.dt.nTable).width());
+
+      // make sure the headers are the same width as the rest of table
+      oDTSettings.aoDrawCallback.push({
+        "fn": function ( oSettings ) {
+          $(oSettings.nTableWrapper).width($(oSettings.nTable).width());
+        },
+        "sName": "Resize headers"
+      });
+    }
+
+    // fix the width and add table layout fixed.
+    if (this.s.bAddFixed) {
+      // Set the table to minimum size so that it doesn't stretch too far
+      $(this.s.dt.nTable).width("10px");
+      $(this.s.dt.nTable).width($(this.s.dt.nTable).width()).css('table-layout','fixed');
+    }
     return this;
   };
 
@@ -2520,24 +2545,22 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @example
      *    // DataTables initialisation with ColReorder
      *    var table = $('#example').dataTable( {
-     *        "sDom": 'Rlfrtip'
-     *    } );
+        *        "sDom": 'Rlfrtip'
+        *    } );
      *
      *    // Add click event to a button to reset the ordering
      *    $('#resetOrdering').click( function (e) {
-     *        e.preventDefault();
-     *        $.fn.dataTable.ColReorder( table ).fnReset();
-     *    } );
+        *        e.preventDefault();
+        *        $.fn.dataTable.ColReorder( table ).fnReset();
+        *    } );
      */
-    "fnReset": function ()
-    {
+    "fnReset": function () {
       var a = [];
-      for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
-      {
-        a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
+      for (var i = 0, iLen = this.s.dt.aoColumns.length; i < iLen; i++) {
+        a.push(this.s.dt.aoColumns[i]._ColReorder_iOrigCol);
       }
 
-      this._fnOrderColumns( a );
+      this._fnOrderColumns(a);
 
       return this;
     },
@@ -2548,8 +2571,7 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @deprecated `fnOrder` should be used in preference to this method.
      *      `fnOrder` acts as a getter/setter.
      */
-    "fnGetCurrentOrder": function ()
-    {
+    "fnGetCurrentOrder": function () {
       return this.fnOrder();
     },
 
@@ -2563,7 +2585,8 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @example
      *    // Get column ordering for the table
      *    var order = $.fn.dataTable.ColReorder( dataTable ).fnOrder();
-     *//**
+     */
+    /**
      * Set the order of the columns, from the positions identified in the
      * ordering array given. Note that ColReorder takes a brute force approach
      * to reordering, so it is possible multiple reordering events will occur
@@ -2589,22 +2612,49 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *      $.fn.dataTable.ColReorder( '#example' ).fnOrder().reverse()
      *    );
      */
-    "fnOrder": function ( set )
-    {
-      if ( set === undefined )
-      {
+    "fnOrder": function (set) {
+      if (set === undefined) {
         var a = [];
-        for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
-        {
-          a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
+        for (var i = 0, iLen = this.s.dt.aoColumns.length; i < iLen; i++) {
+          a.push(this.s.dt.aoColumns[i]._ColReorder_iOrigCol);
         }
         return a;
       }
 
-      this._fnOrderColumns( fnInvertKeyValues( set ) );
+      this._fnOrderColumns(fnInvertKeyValues(set));
 
       return this;
     },
+
+    /**
+     * fnGetColumnSelectList - return html list of columns columns, with selected columns checked
+     *  @return {string} Html string
+     */
+    fnGetColumnSelectList : function() {
+
+      var tp,i;
+      var availableFields = this.s.dt.aoColumns;
+      var html ='<div class="selcol1">';
+      var d2 = (availableFields.length-1) /2;
+      for (i=0;i<availableFields.length;i++) {
+        tp = "col"+(i%2);
+        if (i > d2) {
+          html += '</div><div class="selcol2">';
+          d2 = 99999999;
+        }
+        var selected = availableFields[i].bVisible;
+        var title = availableFields[i].sTitle;
+        var mData = availableFields[i].mData;
+        html += '<label class="'+tp+'">'+
+          '<input name="columns" type="checkbox" checked="'+(selected ? "checked" : "")+'" value="'+mData+'">'+
+          title + '</label>';
+      }
+      html  += "</div>";
+
+      return html;
+    },
+
+
 
 
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -2617,15 +2667,13 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns void
      *  @private
      */
-    "_fnConstruct": function ()
-    {
+    "_fnConstruct": function () {
       var that = this;
       var iLen = this.s.dt.aoColumns.length;
       var i;
 
       /* Columns discounted from reordering - counting left to right */
-      if ( this.s.init.iFixedColumns )
-      {
+      if (this.s.init.iFixedColumns) {
         this.s.fixed = this.s.init.iFixedColumns;
       }
 
@@ -2635,17 +2683,60 @@ $.extend( $.fn.dataTableExt.oPagination, {
         0;
 
       /* Drop callback initialisation option */
-      if ( this.s.init.fnReorderCallback )
-      {
+      if (this.s.init.fnReorderCallback) {
         this.s.dropCallback = this.s.init.fnReorderCallback;
       }
 
+      /* Allow reorder */
+      if (typeof this.s.init.allowReorder != 'undefined') {
+        this.s.allowReorder = this.s.init.allowReorder;
+      }
+
+      /* Allow resize */
+      if (typeof this.s.init.allowResize != 'undefined') {
+        this.s.allowResize = this.s.init.allowResize;
+      }
+
+      /* Allow header double click */
+      if (typeof this.s.init.allowHeaderDoubleClick != 'undefined') {
+        this.s.allowHeaderDoubleClick = this.s.init.allowHeaderDoubleClick;
+      }
+
+      /* Allow header contextmenu */
+      if (typeof this.s.init.headerContextMenu == 'function') {
+        this.s.headerContextMenu = this.s.init.headerContextMenu;
+      }
+      else if (this.s.init.headerContextMenu) {
+        this.s.headerContextMenu = this._fnDefaultContextMenu;
+      }
+      else {
+        this.s.headerContextMenu = false;
+      }
+
+      if (typeof this.s.init.minResizeWidth != 'undefined') {
+        this.s.minResizeWidth = this.s.init.minResizeWidth;
+      }
+
+      if (typeof this.s.init.bResizeTable != 'undefined') {
+        this.s.bResizeTable = this.s.init.bResizeTable;
+      }
+
+      if (typeof this.s.init.bResizeTableWrapper != 'undefined') {
+        this.s.bResizeTableWrapper = this.s.init.bResizeTableWrapper;
+      }
+
+      if (typeof this.s.init.bAddFixed != 'undefined') {
+        this.s.bAddFixed = this.s.init.bAddFixed;
+      }
+
+      if (typeof this.s.init.fnResizeTableCallback == 'function') {
+        this.s.fnResizeTableCallback = this.s.init.fnResizeTableCallback;
+      }
+
       /* Add event handlers for the drag and drop, and also mark the original column order */
-      for ( i = 0; i < iLen; i++ )
-      {
-        if ( i > this.s.fixed-1 && i < iLen - this.s.fixedRight )
-        {
-          this._fnMouseListener( i, this.s.dt.aoColumns[i].nTh );
+      for (i = 0; i < iLen; i++) {
+        if (i > this.s.fixed - 1 && i < iLen - this.s.fixedRight) {
+          this._fnMouseListener(i, this.s.dt.aoColumns[i].nTh);
         }
 
         /* Mark the original column order for later reference */
@@ -2653,56 +2744,137 @@ $.extend( $.fn.dataTableExt.oPagination, {
       }
 
       /* State saving */
-      this.s.dt.oApi._fnCallbackReg( this.s.dt, 'aoStateSaveParams', function (oS, oData) {
-        that._fnStateSave.call( that, oData );
-      }, "ColReorder_State" );
+      this.s.dt.oApi._fnCallbackReg(this.s.dt, 'aoStateSaveParams', function (oS, oData) {
+        that._fnStateSave.call(that, oData);
+      }, "ColReorder_State");
 
       /* An initial column order has been specified */
       var aiOrder = null;
-      if ( this.s.init.aiOrder )
-      {
+      if (this.s.init.aiOrder) {
         aiOrder = this.s.init.aiOrder.slice();
       }
 
       /* State loading, overrides the column order given */
-      if ( this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
-        this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length )
-      {
+      if (this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
+        this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length) {
         aiOrder = this.s.dt.oLoadedState.ColReorder;
       }
 
-      /* If we have an order to apply - do so */
-      if ( aiOrder )
-      {
+      /* Load Column Sizes */
+      var asSizes = null;
+      if (this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColSizes != 'undefined' &&
+        this.s.dt.oLoadedState.ColSizes.length == this.s.dt.aoColumns.length) {
+        asSizes = this.s.dt.oLoadedState.ColSizes;
+      }
+
+      if (asSizes) {
+        // Apply the sizes to the column sWidth settings
+        for (i = 0, iLen = this.s.dt.aoColumns.length; i < iLen; i++)
+          this.s.dt.aoColumns[i].sWidth = asSizes[i];
+      }
+
+      /* If we have an order and/or sizing to apply - do so */
+      if (aiOrder || asSizes) {
         /* We might be called during or after the DataTables initialisation. If before, then we need
          * to wait until the draw is done, if after, then do what we need to do right away
          */
-        if ( !that.s.dt._bInitComplete )
-        {
+        if (!that.s.dt._bInitComplete) {
           var bDone = false;
-          this.s.dt.aoDrawCallback.push( {
+          this.s.dt.aoDrawCallback.push({
             "fn": function () {
-              if ( !that.s.dt._bInitComplete && !bDone )
-              {
+              if (!that.s.dt._bInitComplete && !bDone) {
                 bDone = true;
-                var resort = fnInvertKeyValues( aiOrder );
-                that._fnOrderColumns.call( that, resort );
+                if (aiOrder) {
+                  var resort = fnInvertKeyValues(aiOrder);
+                  that._fnOrderColumns.call(that, resort);
+                }
+                if (asSizes)
+                  that._fnResizeColumns.call(that);
               }
             },
             "sName": "ColReorder_Pre"
-          } );
+          });
         }
-        else
-        {
-          var resort = fnInvertKeyValues( aiOrder );
-          that._fnOrderColumns.call( that, resort );
+        else {
+          if (aiOrder) {
+            var resort = fnInvertKeyValues(aiOrder);
+            that._fnOrderColumns.call(that, resort);
+          }
+          if (asSizes)
+            that._fnResizeColumns.call(that);
         }
-      }
-      else {
-        this._fnSetColumnIndexes();
       }
     },
 
+    /**
+     * Default Context menu to display the column selectors
+     *  @method  _fnDefaultContextMenu
+     *  @param   Object e Event object of the contextmenu (right click) event
+     *  @param   Object settings The datatables settings object
+     *  @param   Object ColReorderObj The ColReorder object
+     *  @returns void
+     *  @private
+     */
+    "_fnDefaultContextMenu" : function(e,settings,thatObj) {
+      var colSelects = thatObj.fnGetColumnSelectList();
+      var myelm = $('<div></div>');
+      myelm.append(colSelects);
+      $("input",myelm).off("change").on("change", function(e) {
+        var index = $('input',myelm).index($(this));
+        var checked = $(this).is(":checked");
+        settings.oInstance.fnSetColumnVis(index,checked,true);
+      });
+
+      if (jQuery.ui) {
+        myelm.dialog({
+          "position":[e.clientX,e.clientY],
+          "title":"Select Columns",
+          "modal":true,
+          "autoOpen":true,
+          "close":function(event,ui) {
+            myelm.remove();
+          }
+        });
+      }
+      else {
+        var overlay = $('<div class="overlayDiv"></div>').appendTo("body").css({"position":"fixed",top:0,left:0, width:"100%",height:"100%","z-index":5000});
+        myelm.appendTo("body").css({position:"absolute", top:e.clientY-2, "background-color":"grey", left:e.clientX-2, "z-index":5005, "border":"1px solid black"});
+        var timer = 0;
+        myelm.mouseover(function(e) {
+          if (timer) {
+            clearTimeout(timer);
+          }
+        });
+
+        myelm.mouseout(function(e) {
+          if (timer) {
+            clearTimeout(timer);
+          }
+          timer = setTimeout(
+            function() {
+              overlay.remove();
+              myelm.remove();
+            },200);
+        });
+      }
+
+    },
+
+    /**
+     * Set the column sizes (widths) from an array
+     *  @method  _fnResizeColumns
+     *  @returns void
+     *  @private
+     */
+    "_fnResizeColumns": function () {
+      for (var i = 0, iLen = this.s.dt.aoColumns.length; i < iLen; i++) {
+        if (this.s.dt.aoColumns[i].sWidth)
+          this.s.dt.aoColumns[i].nTh.style.width = this.s.dt.aoColumns[i].sWidth;
+      }
+
+      /* Save the state */
+      // this.s.dt.oInstance.oApi._fnSaveState(this.s.dt);
+    },
 
     /**
      * Set the column order from an array
@@ -2711,38 +2883,31 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns void
      *  @private
      */
-    "_fnOrderColumns": function ( a )
-    {
-      if ( a.length != this.s.dt.aoColumns.length )
-      {
-        this.s.dt.oInstance.oApi._fnLog( this.s.dt, 1, "ColReorder - array reorder does not "+
-          "match known number of columns. Skipping." );
+    "_fnOrderColumns": function (a) {
+      if (a.length != this.s.dt.aoColumns.length) {
+        this.s.dt.oInstance.oApi._fnLog(this.s.dt, 1, "ColReorder - array reorder does not " +
+          "match known number of columns. Skipping.");
         return;
       }
 
-      for ( var i=0, iLen=a.length ; i<iLen ; i++ )
-      {
-        var currIndex = $.inArray( i, a );
-        if ( i != currIndex )
-        {
+      for (var i = 0, iLen = a.length; i < iLen; i++) {
+        var currIndex = $.inArray(i, a);
+        if (i != currIndex) {
           /* Reorder our switching array */
-          fnArraySwitch( a, currIndex, i );
+          fnArraySwitch(a, currIndex, i);
 
           /* Do the column reorder in the table */
-          this.s.dt.oInstance.fnColReorder( currIndex, i );
+          this.s.dt.oInstance.fnColReorder(currIndex, i);
         }
       }
 
       /* When scrolling we need to recalculate the column sizes to allow for the shift */
-      if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
-      {
+      if (this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "") {
         this.s.dt.oInstance.fnAdjustColumnSizing();
       }
 
       /* Save the state */
-      this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
-
-      this._fnSetColumnIndexes();
+      this.s.dt.oInstance.oApi._fnSaveState(this.s.dt);
     },
 
 
@@ -2755,55 +2920,33 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns string JSON encoded cookie string for DataTables
      *  @private
      */
-    "_fnStateSave": function ( oState )
-    {
+    "_fnStateSave": function (oState) {
       var i, iLen, aCopy, iOrigColumn;
       var oSettings = this.s.dt;
-      var columns = oSettings.aoColumns;
-
-      oState.ColReorder = [];
 
       /* Sorting */
-      if ( oState.aaSorting ) {
-        // 1.10.0-
-        for ( i=0 ; i<oState.aaSorting.length ; i++ ) {
-          oState.aaSorting[i][0] = columns[ oState.aaSorting[i][0] ]._ColReorder_iOrigCol;
-        }
-
-        var aSearchCopy = $.extend( true, [], oState.aoSearchCols );
-
-        for ( i=0, iLen=columns.length ; i<iLen ; i++ )
-        {
-          iOrigColumn = columns[i]._ColReorder_iOrigCol;
-
-          /* Column filter */
-          oState.aoSearchCols[ iOrigColumn ] = aSearchCopy[i];
-
-          /* Visibility */
-          oState.abVisCols[ iOrigColumn ] = columns[i].bVisible;
-
-          /* Column reordering */
-          oState.ColReorder.push( iOrigColumn );
-        }
+      for (i = 0; i < oState.aaSorting.length; i++) {
+        oState.aaSorting[i][0] = oSettings.aoColumns[oState.aaSorting[i][0]]._ColReorder_iOrigCol;
       }
-      else if ( oState.order ) {
-        // 1.10.1+
-        for ( i=0 ; i<oState.order.length ; i++ ) {
-          oState.order[i][0] = columns[ oState.order[i][0] ]._ColReorder_iOrigCol;
-        }
 
-        var stateColumnsCopy = $.extend( true, [], oState.columns );
+      var aSearchCopy = $.extend(true, [], oState.aoSearchCols);
+      oState.ColReorder = [];
+      oState.ColSizes = [];
 
-        for ( i=0, iLen=columns.length ; i<iLen ; i++ )
-        {
-          iOrigColumn = columns[i]._ColReorder_iOrigCol;
+      for (i = 0, iLen = oSettings.aoColumns.length; i < iLen; i++) {
+        iOrigColumn = oSettings.aoColumns[i]._ColReorder_iOrigCol;
 
-          /* Columns */
-          oState.columns[ iOrigColumn ] = stateColumnsCopy[i];
+        /* Column filter */
+        oState.aoSearchCols[iOrigColumn] = aSearchCopy[i];
 
-          /* Column reordering */
-          oState.ColReorder.push( iOrigColumn );
-        }
+        /* Visibility */
+        oState.abVisCols[iOrigColumn] = oSettings.aoColumns[i].bVisible;
+
+        /* Column reordering */
+        oState.ColReorder.push(iOrigColumn);
+
+        /* Column Sizes */
+        oState.ColSizes[iOrigColumn] = oSettings.aoColumns[i].sWidth;
       }
     },
 
@@ -2820,13 +2963,119 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns void
      *  @private
      */
-    "_fnMouseListener": function ( i, nTh )
-    {
+    "_fnMouseListener": function (i, nTh) {
       var that = this;
-      $(nTh).on( 'mousedown.ColReorder', function (e) {
+
+      var thead = $(nTh).closest('thead');
+      // listen to mousemove event for resize
+      if (this.s.allowResize) {
+        //$(nTh).bind('mousemove.ColReorder', function (e) {
+        thead.bind('mousemove.ColReorder', function (e) {
+          var nTable = that.s.dt.nTable;
+          if (that.dom.drag === null && that.dom.resize === null) {
+            /* Store information about the mouse position */
+            var nThTarget = e.target.nodeName == "TH" ? e.target : $(e.target).parents('TH')[0];
+            var offset = $(nThTarget).offset();
+            var nLength = $(nThTarget).innerWidth();
+
+            /* are we on the col border (if so, resize col) */
+            if (Math.abs(e.pageX - Math.round(offset.left + nLength)) <= 5) {
+              $(nThTarget).css({ 'cursor': 'col-resize' });
+              // catch gaps between cells
+              //$(nTable).css({'cursor' : 'col-resize'});
+              that.dom.resizeCol = "right";
+            }
+            else if ((e.pageX - offset.left) < 5) {
+              $(nThTarget).css({'cursor' : 'col-resize'});
+              //$(nTable).css({'cursor' : 'col-resize'});
+              that.dom.resizeCol = "left";
+            }
+            else {
+              $(nThTarget).css({ 'cursor': 'pointer' });
+              //$(nTable).css({'cursor' : 'pointer'});
+            }
+          }
+        });
+
+
+      }
+
+      $(nTh).on('mousedown.ColReorder', function (e) {
         e.preventDefault();
-        that._fnMouseDown.call( that, e, nTh );
-      } );
+        that._fnMouseDown.call(that, e, nTh, i);
+      });
+
+      // Add doubleclick also
+      // It is best to disable sorting if using double click
+      if (this.s.allowHeaderDoubleClick) {
+        $(nTh).on("dblclick.ColReorder", function(e) {
+          e.preventDefault();
+          that._fnDblClick.call(that, e, nTh, i);
+        });
+      }
+
+      if (this.s.headerContextMenu) {
+        $(nTh).off("contextmenu.ColReorder").on("contextmenu.ColReorder", function(e) {
+          e.preventDefault();
+          that.s.headerContextMenu.call(this,e,that.s.dt,that);
+        });
+
+      }
+    },
+
+
+    /**
+     * Double click on a TH element in the table header
+     *  @method  _fnMouseDown
+     *  @param   event e Mouse event
+     *  @param   element nTh TH element to be resized
+     *  @returns void
+     *  @private
+     */
+    "_fnDblClick": function (e, nTh, index) {
+      var nTable = this.s.dt.nTable;
+      var tableWidth = $(nTable).width();
+      var aoColumns = this.s.dt.aoColumns;
+
+      var realWidths = $.map($('th',$(this.s.dt.nThead)), function(l) {return $(l).width();});
+      var nThWidth = $(nTh).width();
+      var newWidth;
+      var that = this;
+
+      var tableResizeIt = function() {
+        var newTableWidth = tableWidth + newWidth - nThWidth;
+
+        $(nTable).width(newTableWidth);
+        $(nTable).css('table-layout',"fixed");
+        $(nTh).width(newWidth);
+
+        aoColumns[index].sWidth = newWidth+"px";
+        that.s.fnResizeTableCallback(nTable,newTableWidth,newTableWidth-tableWidth);
+      };
+
+      if ($(nTh).hasClass('maxwidth')) {
+        var newHead = $(nTable).clone();
+        $('tbody', newHead).remove();
+        var newItem = $(nTh).clone();
+        newItem.wrap("<tr />");
+        newItem.wrap("<table />");
+        $(nTable).css({'table-layout':"auto","width":"auto"});
+        this.s.dt.oFeatures.bAutoWidth = true;
+        // Lets try resizing to headers instead
+        newWidth = this.s.minResizeWidth;
+        $(nTh).removeClass('maxwidth');
+      }
+
+      else {
+        $(nTable).css({'table-layout':"auto","width":"auto"});
+        newWidth = $('th',nTable).eq(index).width();
+
+        $(nTh).addClass("maxwidth");
+        tableResizeIt();
+      }
+
+
+
     },
 
 
@@ -2838,37 +3087,80 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns void
      *  @private
      */
-    "_fnMouseDown": function ( e, nTh )
-    {
+    "_fnMouseDown": function (e, nTh, i) {
       var that = this;
+      var target, offset, idx, nThNext, nThPrev;
+      /* are we resizing a column ? */
+      if ($(nTh).css('cursor') == 'col-resize') {
+        // are we at the right or left?
+        this.s.mouse.startX = e.pageX;
+        this.s.tableWidth = $(nTh).closest("table").width();
 
-      /* Store information about the mouse position */
-      var target = $(e.target).closest('th, td');
-      var offset = target.offset();
-      var idx = parseInt( $(nTh).attr('data-column-index'), 10 );
 
-      if ( idx === undefined ) {
-        return;
+        // If we are at the left end, we expand the previous column
+        if (this.dom.resizeCol == "left") {
+          nThPrev = $(nTh).prev();
+          this.s.mouse.startWidth = $(nThPrev).width();
+          this.s.mouse.resizeElem = $(nThPrev);
+          nThNext = $(nTh).next();
+          this.s.mouse.nextStartWidth = $(nTh).width();
+          this.s.mouse.targetIndex = $('th', nTh.parentNode).index(nThPrev);
+          this.s.mouse.fromIndex = this.s.dt.oInstance.oApi._fnVisibleToColumnIndex(this.s.dt, this.s.mouse.targetIndex);
+        }
+
+        // If we are at the right end of column, we expand the current column
+        else {
+          this.s.mouse.startWidth = $(nTh).width();
+          this.s.mouse.resizeElem = $(nTh);
+          nThNext = $(nTh).next();
+          this.s.mouse.nextStartWidth = $(nThNext).width();
+          this.s.mouse.targetIndex = $('th', nTh.parentNode).index(nTh);
+          this.s.mouse.fromIndex = this.s.dt.oInstance.oApi._fnVisibleToColumnIndex(this.s.dt, this.s.mouse.targetIndex);
+        }
+
+        that.dom.resize = true;
+        ////////////////////
+        //Martin Marchetta
+        //a. Disable column sorting so as to avoid issues when finishing column resizing
+        target = $(e.target).closest('th, td');
+        offset = target.offset();
+        idx = $.inArray(target[0], $.map(this.s.dt.aoColumns, function (o) { return o.nTh; }));
+        // store state so we don't tunr on sorting where we don't want it
+        this.s.dt.aoColumns[idx]._oldbSortable = this.s.dt.aoColumns[idx].bSortable;
+        this.s.dt.aoColumns[idx].bSortable = false;
+        //b. Disable Autowidth feature (now the user is in charge of setting column width so keeping this enabled looses changes after operations)
+        this.s.dt.oFeatures.bAutoWidth = false;
+        ////////////////////
       }
+      else if (this.s.allowReorder) {
+        that.dom.resize = null;
+        /* Store information about the mouse position */
+        target = $(e.target).closest('th, td');
+        offset = target.offset();
+        idx = $.inArray(target[0], $.map(this.s.dt.aoColumns, function (o) { return o.nTh; }));
 
-      this.s.mouse.startX = e.pageX;
-      this.s.mouse.startY = e.pageY;
-      this.s.mouse.offsetX = e.pageX - offset.left;
-      this.s.mouse.offsetY = e.pageY - offset.top;
-      this.s.mouse.target = this.s.dt.aoColumns[ idx ].nTh;//target[0];
-      this.s.mouse.targetIndex = idx;
-      this.s.mouse.fromIndex = idx;
+        if (idx === -1) {
+          return;
+        }
 
-      this._fnRegions();
+        this.s.mouse.startX = e.pageX;
+        this.s.mouse.startY = e.pageY;
+        this.s.mouse.offsetX = e.pageX - offset.left;
+        this.s.mouse.offsetY = e.pageY - offset.top;
+        this.s.mouse.target = target[0];
+        this.s.mouse.targetIndex = idx;
+        this.s.mouse.fromIndex = idx;
 
+        this._fnRegions();
+      }
       /* Add event handlers to the document */
-      $(document)
-        .on( 'mousemove.ColReorder', function (e) {
-          that._fnMouseMove.call( that, e );
-        } )
-        .on( 'mouseup.ColReorder', function (e) {
-          that._fnMouseUp.call( that, e );
-        } );
+      $(document).on('mousemove.ColReorder', function (e) {
+        that._fnMouseMove.call(that, e, i);
+      }).on('mouseup.ColReorder', function (e) {
+        setTimeout(function () {
+          that._fnMouseUp.call(that, e, i);
+        }, 10);
+      });
     },
 
 
@@ -2879,59 +3171,134 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns void
      *  @private
      */
-    "_fnMouseMove": function ( e )
-    {
+    "_fnMouseMove": function (e) {
       var that = this;
+      ////////////////////
+      //Martin Marchetta: Determine if ScrollX is enabled
+      var scrollXEnabled;
 
-      if ( this.dom.drag === null )
-      {
-        /* Only create the drag element if the mouse has moved a specific distance from the start
-         * point - this allows the user to make small mouse movements when sorting and not have a
-         * possibly confusing drag element showing up
-         */
-        if ( Math.pow(
-          Math.pow(e.pageX - this.s.mouse.startX, 2) +
-          Math.pow(e.pageY - this.s.mouse.startY, 2), 0.5 ) < 5 )
-        {
-          return;
+      scrollXEnabled = this.s.dt.oInit.sScrollX === "" ? false : true;
+
+      //Keep the current table's width (used in case sScrollX is enabled to resize the whole table, giving an Excel-like behavior)
+      if (this.table_size < 0 && scrollXEnabled && $('div.dataTables_scrollHead', this.s.dt.nTableWrapper) !== undefined) {
+        if ($('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length > 0)
+          this.table_size = $($('div.dataTables_scrollHead', this.s.dt.nTableWrapper)[0].childNodes[0].childNodes[0]).width();
+      }
+      ////////////////////
+
+      /* are we resizing a column ? */
+      if (this.dom.resize) {
+        var nTh = this.s.mouse.resizeElem;
+        var nThNext = $(nTh).next();
+        var moveLength = e.pageX - this.s.mouse.startX;
+        var newWidth = this.s.mouse.startWidth + moveLength;
+        // set a min width of 10 - this would be good to configure
+        if (newWidth < this.s.minResizeWidth) {
+          newWidth = this.s.minResizeWidth;
+          moveLength = newWidth - this.s.mouse.startWidth ;
         }
-        this._fnCreateDragNode();
-      }
-
-      /* Position the element - we respect where in the element the click occured */
-      this.dom.drag.css( {
-        left: e.pageX - this.s.mouse.offsetX,
-        top: e.pageY - this.s.mouse.offsetY
-      } );
-
-      /* Based on the current mouse position, calculate where the insert should go */
-      var bSet = false;
-      var lastToIndex = this.s.mouse.toIndex;
-
-      for ( var i=1, iLen=this.s.aoTargets.length ; i<iLen ; i++ )
-      {
-        if ( e.pageX < this.s.aoTargets[i-1].x + ((this.s.aoTargets[i].x-this.s.aoTargets[i-1].x)/2) )
-        {
-          this.dom.pointer.css( 'left', this.s.aoTargets[i-1].x );
-          this.s.mouse.toIndex = this.s.aoTargets[i-1].to;
-          bSet = true;
-          break;
+        if (moveLength !== 0 && !scrollXEnabled) {
+          $(nThNext).width(this.s.mouse.nextStartWidth - moveLength);
         }
-      }
+        $(nTh).width(this.s.mouse.startWidth + moveLength);
 
-      // The insert element wasn't positioned in the array (less than
-      // operator), so we put it at the end
-      if ( !bSet )
-      {
-        this.dom.pointer.css( 'left', this.s.aoTargets[this.s.aoTargets.length-1].x );
-        this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length-1].to;
-      }
+        //Martin Marchetta: Resize the header too (if sScrollX is enabled)
+        if (scrollXEnabled && $('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length) {
+          if ($('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length > 0)
+            $($('div.dataTables_scrollHead', this.s.dt.nTableWrapper)[0].childNodes[0].childNodes[0]).width(this.table_size + moveLength);
+        }
 
-      // Perform reordering if realtime updating is on and the column has moved
-      if ( this.s.init.bRealtime && lastToIndex !== this.s.mouse.toIndex ) {
-        this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
-        this.s.mouse.fromIndex = this.s.mouse.toIndex;
-        this._fnRegions();
+        ////////////////////////
+        //Martin Marchetta: Fixed col resizing when the scroller is enabled.
+        var visibleColumnIndex;
+        //First determine if this plugin is being used along with the smart scroller...
+        if ($('div.dataTables_scrollBody').lenggthll) {
+          //...if so, when resizing the header, also resize the table's body (when enabling the Scroller, the table's header and
+          //body are split into different tables, so the column resizing doesn't work anymore)
+          if ($('div.dataTables_scrollBody').length > 0) {
+            //Since some columns might have been hidden, find the correct one to resize in the table's body
+            var currentColumnIndex;
+            visibleColumnIndex = -1;
+            for (currentColumnIndex = -1; currentColumnIndex < this.s.dt.aoColumns.length - 1 && currentColumnIndex != colResized; currentColumnIndex++) {
+              if (this.s.dt.aoColumns[currentColumnIndex + 1].bVisible)
+                visibleColumnIndex++;
+            }
+
+            //Get the scroller's div
+            tableScroller = $('div.dataTables_scrollBody', this.s.dt.nTableWrapper)[0];
+
+            //Get the table
+            scrollingTableHead = $(tableScroller)[0].childNodes[0].childNodes[0].childNodes[0];
+
+            //Resize the columns
+            if (moveLength  && !scrollXEnabled) {
+              $($(scrollingTableHead)[0].childNodes[visibleColumnIndex + 1]).width(this.s.mouse.nextStartWidth - moveLength);
+            }
+            $($(scrollingTableHead)[0].childNodes[visibleColumnIndex]).width(this.s.mouse.startWidth + moveLength);
+
+            //Resize the table too
+            if (scrollXEnabled) {
+              $($(tableScroller)[0].childNodes[0]).width(this.table_size + moveLength);
+            }
+          }
+        }
+
+        if (this.s.bResizeTable) {
+          var tableMove = this.s.tableWidth + moveLength;
+          $(nTh).closest('table').width(tableMove);
+          this.s.fnResizeTableCallback($(nTh).closest('table'),tableMove,moveLength);
+        }
+
+        ////////////////////////
+
+        return;
+      }
+      else if (this.s.allowReorder) {
+        if (this.dom.drag === null) {
+          /* Only create the drag element if the mouse has moved a specific distance from the start
+           * point - this allows the user to make small mouse movements when sorting and not have a
+           * possibly confusing drag element showing up
+           */
+          if (Math.pow(
+              Math.pow(e.pageX - this.s.mouse.startX, 2) +
+              Math.pow(e.pageY - this.s.mouse.startY, 2), 0.5) < 5) {
+            return;
+          }
+          this._fnCreateDragNode();
+        }
+
+        /* Position the element - we respect where in the element the click occured */
+        this.dom.drag.css({
+          left: e.pageX - this.s.mouse.offsetX,
+          top: e.pageY - this.s.mouse.offsetY
+        });
+
+        /* Based on the current mouse position, calculate where the insert should go */
+        var bSet = false;
+        var lastToIndex = this.s.mouse.toIndex;
+
+        for (var i = 1, iLen = this.s.aoTargets.length; i < iLen; i++) {
+          if (e.pageX < this.s.aoTargets[i - 1].x + ((this.s.aoTargets[i].x - this.s.aoTargets[i - 1].x) / 2)) {
+            this.dom.pointer.css('left', this.s.aoTargets[i - 1].x);
+            this.s.mouse.toIndex = this.s.aoTargets[i - 1].to;
+            bSet = true;
+            break;
+          }
+        }
+
+        // The insert element wasn't positioned in the array (less than
+        // operator), so we put it at the end
+        if (!bSet) {
+          this.dom.pointer.css('left', this.s.aoTargets[this.s.aoTargets.length - 1].x);
+          this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length - 1].to;
+        }
+
+        // Perform reordering if realtime updating is on and the column has moved
+        if (this.s.init.bRealtime && lastToIndex !== this.s.mouse.toIndex) {
+          this.s.dt.oInstance.fnColReorder(this.s.mouse.fromIndex, this.s.mouse.toIndex);
+          this.s.mouse.fromIndex = this.s.mouse.toIndex;
+          this._fnRegions();
+        }
       }
     },
 
@@ -2943,14 +3310,12 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns void
      *  @private
      */
-    "_fnMouseUp": function ( e )
-    {
+    "_fnMouseUp": function (e, colResized) {
       var that = this;
 
-      $(document).off( 'mousemove.ColReorder mouseup.ColReorder' );
+      $(document).off('mousemove.ColReorder mouseup.ColReorder');
 
-      if ( this.dom.drag !== null )
-      {
+      if (this.dom.drag !== null) {
         /* Remove the guide elements */
         this.dom.drag.remove();
         this.dom.pointer.remove();
@@ -2958,23 +3323,93 @@ $.extend( $.fn.dataTableExt.oPagination, {
         this.dom.pointer = null;
 
         /* Actually do the reorder */
-        this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
-        this._fnSetColumnIndexes();
+        this.s.dt.oInstance.fnColReorder(this.s.mouse.fromIndex, this.s.mouse.toIndex);
 
         /* When scrolling we need to recalculate the column sizes to allow for the shift */
-        if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
-        {
+        if (this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "") {
           this.s.dt.oInstance.fnAdjustColumnSizing();
         }
 
-        if ( this.s.dropCallback !== null )
-        {
-          this.s.dropCallback.call( this, this.s.mouse.fromIndex, this.s.mouse.toIndex );
+        if (this.s.dropCallback !== null) {
+          this.s.dropCallback.call(this);
         }
 
         /* Save the state */
-        this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
+        this.s.dt.oInstance.oApi._fnSaveState(this.s.dt);
       }
+      else if (this.dom.resize !== null) {
+        var i;
+        var j;
+        var column;
+        var currentColumn;
+        var aoColumnsColumnindex;
+        var nextVisibleColumnIndex;
+        var previousVisibleColumnIndex;
+        var scrollXEnabled;
+        var resizeCol = this.dom.resizeCol;
+        /*
+         if (resizeCol == 'right') {
+         colResized++;
+         }
+         */
+        for (i = 0; i < this.s.dt.aoColumns.length; i++) {
+          if (this.s.dt.aoColumns[i]._ColReorder_iOrigCol === colResized) {
+            aoColumnsColumnindex = i;
+            break;
+          }
+        }
+
+        // Re-enable column sorting
+        // only if sorting were previously enabled
+        this.s.dt.aoColumns[aoColumnsColumnindex].bSortable = this.s.dt.aoColumns[aoColumnsColumnindex]._oldbSortable;
+
+        // Save the new resized column's width
+        this.s.dt.aoColumns[aoColumnsColumnindex].sWidth = $(this.s.mouse.resizeElem).innerWidth() + "px";
+
+        // If other columns might have changed their size, save their size too
+        scrollXEnabled = this.s.dt.oInit.sScrollX === "" ? false : true;
+        if (!scrollXEnabled) {
+          //The colResized index (internal model) here might not match the visible index since some columns might have been hidden
+          for (nextVisibleColumnIndex = colResized + 1; nextVisibleColumnIndex < this.s.dt.aoColumns.length; nextVisibleColumnIndex++) {
+            if (this.s.dt.aoColumns[nextVisibleColumnIndex].bVisible)
+              break;
+          }
+
+          for (previousVisibleColumnIndex = colResized - 1; previousVisibleColumnIndex >= 0; previousVisibleColumnIndex--) {
+            if (this.s.dt.aoColumns[previousVisibleColumnIndex].bVisible)
+              break;
+          }
+
+          if (this.s.dt.aoColumns.length > nextVisibleColumnIndex)
+            this.s.dt.aoColumns[nextVisibleColumnIndex].sWidth = $(this.s.mouse.resizeElem).next().innerWidth() + "px";
+          else { //The column resized is the right-most, so save the sizes of all the columns at the left
+            currentColumn = this.s.mouse.resizeElem;
+            for (i = previousVisibleColumnIndex; i > 0; i--) {
+              if (this.s.dt.aoColumns[i].bVisible) {
+                currentColumn = $(currentColumn).prev();
+                this.s.dt.aoColumns[i].sWidth = $(currentColumn).innerWidth() + "px";
+              }
+            }
+          }
+        }
+
+        //Update the internal storage of the table's width (in case we changed it because the user resized some column and scrollX was enabled
+        if (scrollXEnabled && $('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length) {
+          if ($('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length > 0) {
+            this.table_size = $($('div.dataTables_scrollHead', this.s.dt.nTableWrapper)[0].childNodes[0].childNodes[0]).width();
+          }
+        }
+
+        if (this.s.bResizeTableWrapper) {
+          $(this.s.dt.nTableWrapper).width($(this.s.dt.nTable).width());
+        }
+
+        //Save the state
+        this.s.dt.oInstance.oApi._fnSaveState(this.s.dt);
+      }
+      ///////////////////////////////////////////////////////
+
+      this.dom.resize = null;
     },
 
 
@@ -2985,48 +3420,42 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns void
      *  @private
      */
-    "_fnRegions": function ()
-    {
+    "_fnRegions": function () {
       var aoColumns = this.s.dt.aoColumns;
 
-      this.s.aoTargets.splice( 0, this.s.aoTargets.length );
+      this.s.aoTargets.splice(0, this.s.aoTargets.length);
 
-      this.s.aoTargets.push( {
-        "x":  $(this.s.dt.nTable).offset().left,
+      this.s.aoTargets.push({
+        "x": $(this.s.dt.nTable).offset().left,
         "to": 0
-      } );
+      });
 
       var iToPoint = 0;
-      for ( var i=0, iLen=aoColumns.length ; i<iLen ; i++ )
-      {
+      for (var i = 0, iLen = aoColumns.length; i < iLen; i++) {
         /* For the column / header in question, we want it's position to remain the same if the
          * position is just to it's immediate left or right, so we only incremement the counter for
          * other columns
          */
-        if ( i != this.s.mouse.fromIndex )
-        {
+        if (i != this.s.mouse.fromIndex) {
           iToPoint++;
         }
 
-        if ( aoColumns[i].bVisible )
-        {
-          this.s.aoTargets.push( {
-            "x":  $(aoColumns[i].nTh).offset().left + $(aoColumns[i].nTh).outerWidth(),
+        if (aoColumns[i].bVisible) {
+          this.s.aoTargets.push({
+            "x": $(aoColumns[i].nTh).offset().left + $(aoColumns[i].nTh).outerWidth(),
             "to": iToPoint
-          } );
+          });
         }
       }
 
       /* Disallow columns for being reordered by drag and drop, counting right to left */
-      if ( this.s.fixedRight !== 0 )
-      {
-        this.s.aoTargets.splice( this.s.aoTargets.length - this.s.fixedRight );
+      if (this.s.fixedRight !== 0) {
+        this.s.aoTargets.splice(this.s.aoTargets.length - this.s.fixedRight);
       }
 
       /* Disallow columns for being reordered by drag and drop, counting left to right */
-      if ( this.s.fixed !== 0 )
-      {
-        this.s.aoTargets.splice( 0, this.s.fixed );
+      if (this.s.fixed !== 0) {
+        this.s.aoTargets.splice(0, this.s.fixed);
       }
     },
 
@@ -3038,11 +3467,10 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns void
      *  @private
      */
-    "_fnCreateDragNode": function ()
-    {
+    "_fnCreateDragNode": function () {
       var scrolling = this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "";
 
-      var origCell = this.s.dt.aoColumns[ this.s.mouse.targetIndex ].nTh;
+      var origCell = this.s.dt.aoColumns[this.s.mouse.targetIndex].nTh;
       var origTr = origCell.parentNode;
       var origThead = origTr.parentNode;
       var origTable = origThead.parentNode;
@@ -3052,35 +3480,35 @@ $.extend( $.fn.dataTableExt.oPagination, {
       // fastest and least resource intensive way I could think of cloning
       // the table with just a single header cell in it.
       this.dom.drag = $(origTable.cloneNode(false))
-        .addClass( 'DTCR_clonedTable' )
+        .addClass('DTCR_clonedTable')
         .append(
-          origThead.cloneNode(false).appendChild(
-            origTr.cloneNode(false).appendChild(
-              cloneCell[0]
-            )
+        origThead.cloneNode(false).appendChild(
+          origTr.cloneNode(false).appendChild(
+            cloneCell[0]
           )
         )
-        .css( {
+      )
+        .css({
           position: 'absolute',
           top: 0,
           left: 0,
           width: $(origCell).outerWidth(),
           height: $(origCell).outerHeight()
-        } )
-        .appendTo( 'body' );
+        })
+        .appendTo('body');
 
       this.dom.pointer = $('<div></div>')
-        .addClass( 'DTCR_pointer' )
-        .css( {
+        .addClass('DTCR_pointer')
+        .css({
           position: 'absolute',
           top: scrolling ?
             $('div.dataTables_scroll', this.s.dt.nTableWrapper).offset().top :
             $(this.s.dt.nTable).offset().top,
-          height : scrolling ?
+          height: scrolling ?
             $('div.dataTables_scroll', this.s.dt.nTableWrapper).height() :
             $(this.s.dt.nTable).height()
-        } )
-        .appendTo( 'body' );
+        })
+        .appendTo('body');
     },
 
     /**
@@ -3089,41 +3517,27 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @returns void
      *  @private
      */
-    "_fnDestroy": function ()
-    {
+    "_fnDestroy": function () {
       var i, iLen;
 
-      for ( i=0, iLen=this.s.dt.aoDrawCallback.length ; i<iLen ; i++ )
-      {
-        if ( this.s.dt.aoDrawCallback[i].sName === 'ColReorder_Pre' )
-        {
-          this.s.dt.aoDrawCallback.splice( i, 1 );
+      for (i = 0, iLen = this.s.dt.aoDrawCallback.length; i < iLen; i++) {
+        if (this.s.dt.aoDrawCallback[i].sName === 'ColReorder_Pre') {
+          this.s.dt.aoDrawCallback.splice(i, 1);
           break;
         }
       }
 
-      $(this.s.dt.nTHead).find( '*' ).off( '.ColReorder' );
+      for (i = 0, iLen = ColReorder.aoInstances.length; i < iLen; i++) {
+        if (ColReorder.aoInstances[i] === this) {
+          ColReorder.aoInstances.splice(i, 1);
+          break;
+        }
+      }
 
-      $.each( this.s.dt.aoColumns, function (i, column) {
-        $(column.nTh).removeAttr('data-column-index');
-      } );
+      $(this.s.dt.nTHead).find('*').off('.ColReorder');
 
-      this.s.dt._colReorder = null;
+      this.s.dt.oInstance._oPluginColReorder = null;
       this.s = null;
-    },
-
-
-    /**
-     * Add a data attribute to the column headers, so we know the index of
-     * the row to be reordered. This allows fast detection of the index, and
-     * for this plug-in to work with FixedHeader which clones the nodes.
-     *  @private
-     */
-    "_fnSetColumnIndexes": function ()
-    {
-      $.each( this.s.dt.aoColumns, function (i, column) {
-        $(column.nTh).attr('data-column-index', i);
-      } );
     }
   };
 
@@ -3134,6 +3548,16 @@ $.extend( $.fn.dataTableExt.oPagination, {
   /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
    * Static parameters
    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+  /**
+   * Array of all ColReorder instances for later reference
+   *  @property ColReorder.aoInstances
+   *  @type     array
+   *  @default  []
+   *  @static
+   *  @private
+   */
+  ColReorder.aoInstances = [];
 
 
   /**
@@ -3152,19 +3576,19 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "aiOrder": [ 4, 3, 2, 1, 0 ]
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "aiOrder": [ 4, 3, 2, 1, 0 ]
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "aiOrder": [ 4, 3, 2, 1, 0 ]
-     *      } );
+        *          "aiOrder": [ 4, 3, 2, 1, 0 ]
+        *      } );
      */
     aiOrder: null,
 
@@ -3180,19 +3604,19 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "bRealtime": true
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "bRealtime": true
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "bRealtime": true
-     *      } );
+        *          "bRealtime": true
+        *      } );
      */
     bRealtime: false,
 
@@ -3205,19 +3629,19 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "iFixedColumns": 1
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "iFixedColumns": 1
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "iFixedColumns": 1
-     *      } );
+        *          "iFixedColumns": 1
+        *      } );
      */
     iFixedColumns: 0,
 
@@ -3229,19 +3653,19 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "iFixedColumnsRight": 1
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "iFixedColumnsRight": 1
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "iFixedColumnsRight": 1
-     *      } );
+        *          "iFixedColumnsRight": 1
+        *      } );
      */
     iFixedColumnsRight: 0,
 
@@ -3253,26 +3677,53 @@ $.extend( $.fn.dataTableExt.oPagination, {
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "fnReorderCallback": function () {
-     *                  alert( 'Columns reordered' );
-     *              }
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "fnReorderCallback": function () {
+        *                  alert( 'Columns reordered' );
+        *              }
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "fnReorderCallback": function () {
-     *              alert( 'Columns reordered' );
-     *          }
-     *      } );
+        *          "fnReorderCallback": function () {
+        *              alert( 'Columns reordered' );
+        *          }
+        *      } );
      */
     fnReorderCallback: null
   };
+
+
+
+
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * Static functions
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+  /**
+   * `Deprecated` Reset the column ordering for a DataTables instance
+   *  @method  ColReorder.fnReset
+   *  @param   object oTable DataTables instance to consider
+   *  @returns void
+   *  @static
+   *  @deprecated Use `ColReorder( table ).fnReset()` instead.
+   */
+  ColReorder.fnReset = function (oTable) {
+    for (var i = 0, iLen = ColReorder.aoInstances.length; i < iLen; i++) {
+      if (ColReorder.aoInstances[i].s.dt.oInstance == oTable) {
+        ColReorder.aoInstances[i].fnReset();
+      }
+    }
+  };
+
+
+
 
 
 
@@ -3282,93 +3733,59 @@ $.extend( $.fn.dataTableExt.oPagination, {
 
   /**
    * ColReorder version
-   *  @constant  version
+   *  @constant  VERSION
    *  @type      String
    *  @default   As code
    */
-  ColReorder.version = "1.1.3-dev";
+  ColReorder.VERSION = "1.1.0-dev";
+  ColReorder.prototype.VERSION = ColReorder.VERSION;
+
+
 
 
 
   /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * DataTables interfaces
+   * Initialisation
    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-  // Expose
-  $.fn.dataTable.ColReorder = ColReorder;
-  $.fn.DataTable.ColReorder = ColReorder;
-
-
-  // Register a new feature with DataTables
-  if ( typeof $.fn.dataTable == "function" &&
-       typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
-       $.fn.dataTableExt.fnVersionCheck('1.9.3') )
-  {
-    $.fn.dataTableExt.aoFeatures.push( {
-      "fnInit": function( settings ) {
+  /*
+   * Register a new feature with DataTables
+   */
+  if (typeof $.fn.dataTable == "function" &&
+    typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
+    $.fn.dataTableExt.fnVersionCheck('1.9.3')) {
+    $.fn.dataTableExt.aoFeatures.push({
+      "fnInit": function (settings) {
         var table = settings.oInstance;
 
-        if ( ! settings._colReorder ) {
-          var dtInit = settings.oInit;
-          var opts = dtInit.colReorder || dtInit.oColReorder || {};
+        if (table._oPluginColReorder === undefined) {
+          var opts = settings.oInit.oColReorder !== undefined ?
+            settings.oInit.oColReorder :
+          {};
 
-          new ColReorder( settings, opts );
+          table._oPluginColReorder = new ColReorder(settings, opts);
         }
         else {
-          table.oApi._fnLog( settings, 1, "ColReorder attempted to initialise twice. Ignoring second" );
+          table.oApi._fnLog(settings, 1, "ColReorder attempted to initialise twice. Ignoring second");
         }
 
         return null; /* No node for DataTables to insert */
       },
       "cFeature": "R",
       "sFeature": "ColReorder"
-    } );
+    });
   }
   else {
-    alert( "Warning: ColReorder requires DataTables 1.9.3 or greater - www.datatables.net/download");
+    alert("Warning: ColReorder requires DataTables 1.9.3 or greater - www.datatables.net/download");
   }
 
 
-  // API augmentation
-  if ( $.fn.dataTable.Api ) {
-    $.fn.dataTable.Api.register( 'colReorder.reset()', function () {
-      return this.iterator( 'table', function ( ctx ) {
-        ctx._colReorder.fnReset();
-      } );
-    } );
-
-    $.fn.dataTable.Api.register( 'colReorder.order()', function ( set ) {
-      if ( set ) {
-        return this.iterator( 'table', function ( ctx ) {
-          ctx._colReorder.fnOrder( set );
-        } );
-      }
-
-      return this.context.length ?
-        this.context[0]._colReorder.fnOrder() :
-        null;
-    } );
-  }
-
-  return ColReorder;
-  }; // /factory
+  window.ColReorder = ColReorder;
+  $.fn.dataTable.ColReorder = ColReorder;
 
 
-  // Define as an AMD module if possible
-  if ( typeof define === 'function' && define.amd ) {
-    define( ['jquery', 'datatables'], factory );
-  }
-  else if ( typeof exports === 'object' ) {
-      // Node/CommonJS
-      factory( require('jquery'), require('datatables') );
-  }
-  else if ( jQuery && !jQuery.fn.dataTable.ColReorder ) {
-    // Otherwise simply initialise as normal, stopping multiple evaluation
-    factory( jQuery, jQuery.fn.dataTable );
-  }
+})(jQuery, window, document);
 
-
-})(window, document);
 
 
     app.view.dataTable = function(name, baseClassName, properties) {

--- a/dist/backdraft.js
+++ b/dist/backdraft.js
@@ -2028,938 +2028,710 @@ $.extend( $.fn.dataTableExt.oPagination, {
 (function(window, document, undefined) {
 
 
-/**
- * Switch the key value pairing of an index array to be value key (i.e. the old value is now the
- * key). For example consider [ 2, 0, 1 ] this would be returned as [ 1, 2, 0 ].
- *  @method  fnInvertKeyValues
- *  @param   array aIn Array to switch around
- *  @returns array
- */
-function fnInvertKeyValues( aIn )
-{
-  var aRet=[];
-  for ( var i=0, iLen=aIn.length ; i<iLen ; i++ )
+  /**
+   * Switch the key value pairing of an index array to be value key (i.e. the old value is now the
+   * key). For example consider [ 2, 0, 1 ] this would be returned as [ 1, 2, 0 ].
+   *  @method  fnInvertKeyValues
+   *  @param   array aIn Array to switch around
+   *  @returns array
+   */
+  function fnInvertKeyValues( aIn )
   {
-    aRet[ aIn[i] ] = i;
-  }
-  return aRet;
-}
-
-
-/**
- * Modify an array by switching the position of two elements
- *  @method  fnArraySwitch
- *  @param   array aArray Array to consider, will be modified by reference (i.e. no return)
- *  @param   int iFrom From point
- *  @param   int iTo Insert point
- *  @returns void
- */
-function fnArraySwitch( aArray, iFrom, iTo )
-{
-  var mStore = aArray.splice( iFrom, 1 )[0];
-  aArray.splice( iTo, 0, mStore );
-}
-
-
-/**
- * Switch the positions of nodes in a parent node (note this is specifically designed for
- * table rows). Note this function considers all element nodes under the parent!
- *  @method  fnDomSwitch
- *  @param   string sTag Tag to consider
- *  @param   int iFrom Element to move
- *  @param   int Point to element the element to (before this point), can be null for append
- *  @returns void
- */
-function fnDomSwitch( nParent, iFrom, iTo )
-{
-  var anTags = [];
-  for ( var i=0, iLen=nParent.childNodes.length ; i<iLen ; i++ )
-  {
-    if ( nParent.childNodes[i].nodeType == 1 )
+    var aRet=[];
+    for ( var i=0, iLen=aIn.length ; i<iLen ; i++ )
     {
-      anTags.push( nParent.childNodes[i] );
+      aRet[ aIn[i] ] = i;
+    }
+    return aRet;
+  }
+
+
+  /**
+   * Modify an array by switching the position of two elements
+   *  @method  fnArraySwitch
+   *  @param   array aArray Array to consider, will be modified by reference (i.e. no return)
+   *  @param   int iFrom From point
+   *  @param   int iTo Insert point
+   *  @returns void
+   */
+  function fnArraySwitch( aArray, iFrom, iTo )
+  {
+    var mStore = aArray.splice( iFrom, 1 )[0];
+    aArray.splice( iTo, 0, mStore );
+  }
+
+
+  /**
+   * Switch the positions of nodes in a parent node (note this is specifically designed for
+   * table rows). Note this function considers all element nodes under the parent!
+   *  @method  fnDomSwitch
+   *  @param   string sTag Tag to consider
+   *  @param   int iFrom Element to move
+   *  @param   int Point to element the element to (before this point), can be null for append
+   *  @returns void
+   */
+  function fnDomSwitch( nParent, iFrom, iTo )
+  {
+    var anTags = [];
+    for ( var i=0, iLen=nParent.childNodes.length ; i<iLen ; i++ )
+    {
+      if ( nParent.childNodes[i].nodeType == 1 )
+      {
+        anTags.push( nParent.childNodes[i] );
+      }
+    }
+    var nStore = anTags[ iFrom ];
+
+    if ( iTo !== null )
+    {
+      nParent.insertBefore( nStore, anTags[iTo] );
+    }
+    else
+    {
+      nParent.appendChild( nStore );
     }
   }
-  var nStore = anTags[ iFrom ];
 
-  if ( iTo !== null )
+
+
+  var factory = function( $, DataTable ) {
+  "use strict";
+
+  /**
+   * Plug-in for DataTables which will reorder the internal column structure by taking the column
+   * from one position (iFrom) and insert it into a given point (iTo).
+   *  @method  $.fn.dataTableExt.oApi.fnColReorder
+   *  @param   object oSettings DataTables settings object - automatically added by DataTables!
+   *  @param   int iFrom Take the column to be repositioned from this point
+   *  @param   int iTo and insert it into this point
+   *  @returns void
+   */
+  $.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo )
   {
-    nParent.insertBefore( nStore, anTags[iTo] );
-  }
-  else
-  {
-    nParent.appendChild( nStore );
-  }
-}
+    var v110 = $.fn.dataTable.Api ? true : false;
+    var i, iLen, j, jLen, iCols=oSettings.aoColumns.length, nTrs, oCol;
+    var attrMap = function ( obj, prop, mapping ) {
+      if ( ! obj[ prop ] ) {
+        return;
+      }
 
+      var a = obj[ prop ].split('.');
+      var num = a.shift();
 
+      if ( isNaN( num*1 ) ) {
+        return;
+      }
 
-var factory = function( $, DataTable ) {
-"use strict";
+      obj[ prop ] = mapping[ num*1 ]+'.'+a.join('.');
+    };
 
-/**
- * Plug-in for DataTables which will reorder the internal column structure by taking the column
- * from one position (iFrom) and insert it into a given point (iTo).
- *  @method  $.fn.dataTableExt.oApi.fnColReorder
- *  @param   object oSettings DataTables settings object - automatically added by DataTables!
- *  @param   int iFrom Take the column to be repositioned from this point
- *  @param   int iTo and insert it into this point
- *  @returns void
- */
-$.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo )
-{
-  var v110 = $.fn.dataTable.Api ? true : false;
-  var i, iLen, j, jLen, iCols=oSettings.aoColumns.length, nTrs, oCol;
-  var attrMap = function ( obj, prop, mapping ) {
-    if ( ! obj[ prop ] ) {
+    /* Sanity check in the input */
+    if ( iFrom == iTo )
+    {
+      /* Pointless reorder */
       return;
     }
 
-    var a = obj[ prop ].split('.');
-    var num = a.shift();
-
-    if ( isNaN( num*1 ) ) {
+    if ( iFrom < 0 || iFrom >= iCols )
+    {
+      this.oApi._fnLog( oSettings, 1, "ColReorder 'from' index is out of bounds: "+iFrom );
       return;
     }
 
-    obj[ prop ] = mapping[ num*1 ]+'.'+a.join('.');
-  };
-
-  /* Sanity check in the input */
-  if ( iFrom == iTo )
-  {
-    /* Pointless reorder */
-    return;
-  }
-
-  if ( iFrom < 0 || iFrom >= iCols )
-  {
-    this.oApi._fnLog( oSettings, 1, "ColReorder 'from' index is out of bounds: "+iFrom );
-    return;
-  }
-
-  if ( iTo < 0 || iTo >= iCols )
-  {
-    this.oApi._fnLog( oSettings, 1, "ColReorder 'to' index is out of bounds: "+iTo );
-    return;
-  }
-
-  /*
-   * Calculate the new column array index, so we have a mapping between the old and new
-   */
-  var aiMapping = [];
-  for ( i=0, iLen=iCols ; i<iLen ; i++ )
-  {
-    aiMapping[i] = i;
-  }
-  fnArraySwitch( aiMapping, iFrom, iTo );
-  var aiInvertMapping = fnInvertKeyValues( aiMapping );
-
-
-  /*
-   * Convert all internal indexing to the new column order indexes
-   */
-  /* Sorting */
-  for ( i=0, iLen=oSettings.aaSorting.length ; i<iLen ; i++ )
-  {
-    oSettings.aaSorting[i][0] = aiInvertMapping[ oSettings.aaSorting[i][0] ];
-  }
-
-  /* Fixed sorting */
-  if ( oSettings.aaSortingFixed !== null )
-  {
-    for ( i=0, iLen=oSettings.aaSortingFixed.length ; i<iLen ; i++ )
+    if ( iTo < 0 || iTo >= iCols )
     {
-      oSettings.aaSortingFixed[i][0] = aiInvertMapping[ oSettings.aaSortingFixed[i][0] ];
-    }
-  }
-
-  /* Data column sorting (the column which the sort for a given column should take place on) */
-  for ( i=0, iLen=iCols ; i<iLen ; i++ )
-  {
-    oCol = oSettings.aoColumns[i];
-    for ( j=0, jLen=oCol.aDataSort.length ; j<jLen ; j++ )
-    {
-      oCol.aDataSort[j] = aiInvertMapping[ oCol.aDataSort[j] ];
+      this.oApi._fnLog( oSettings, 1, "ColReorder 'to' index is out of bounds: "+iTo );
+      return;
     }
 
-    // Update the column indexes
-    if ( v110 ) {
-      oCol.idx = aiInvertMapping[ oCol.idx ];
-    }
-  }
-
-  if ( v110 ) {
-    // Update 1.10 optimised sort class removal variable
-    $.each( oSettings.aLastSort, function (i, val) {
-      oSettings.aLastSort[i].src = aiInvertMapping[ val.src ];
-    } );
-  }
-
-  /* Update the Get and Set functions for each column */
-  for ( i=0, iLen=iCols ; i<iLen ; i++ )
-  {
-    oCol = oSettings.aoColumns[i];
-
-    if ( typeof oCol.mData == 'number' ) {
-      oCol.mData = aiInvertMapping[ oCol.mData ];
-
-      // regenerate the get / set functions
-      oSettings.oApi._fnColumnOptions( oSettings, i, {} );
-    }
-    else if ( $.isPlainObject( oCol.mData ) ) {
-      // HTML5 data sourced
-      attrMap( oCol.mData, '_',      aiInvertMapping );
-      attrMap( oCol.mData, 'filter', aiInvertMapping );
-      attrMap( oCol.mData, 'sort',   aiInvertMapping );
-      attrMap( oCol.mData, 'type',   aiInvertMapping );
-
-      // regenerate the get / set functions
-      oSettings.oApi._fnColumnOptions( oSettings, i, {} );
-    }
-  }
-
-
-  /*
-   * Move the DOM elements
-   */
-  if ( oSettings.aoColumns[iFrom].bVisible )
-  {
-    /* Calculate the current visible index and the point to insert the node before. The insert
-     * before needs to take into account that there might not be an element to insert before,
-     * in which case it will be null, and an appendChild should be used
+    /*
+     * Calculate the new column array index, so we have a mapping between the old and new
      */
-    var iVisibleIndex = this.oApi._fnColumnIndexToVisible( oSettings, iFrom );
-    var iInsertBeforeIndex = null;
-
-    i = iTo < iFrom ? iTo : iTo + 1;
-    while ( iInsertBeforeIndex === null && i < iCols )
+    var aiMapping = [];
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
     {
-      iInsertBeforeIndex = this.oApi._fnColumnIndexToVisible( oSettings, i );
-      i++;
+      aiMapping[i] = i;
+    }
+    fnArraySwitch( aiMapping, iFrom, iTo );
+    var aiInvertMapping = fnInvertKeyValues( aiMapping );
+
+
+    /*
+     * Convert all internal indexing to the new column order indexes
+     */
+    /* Sorting */
+    for ( i=0, iLen=oSettings.aaSorting.length ; i<iLen ; i++ )
+    {
+      oSettings.aaSorting[i][0] = aiInvertMapping[ oSettings.aaSorting[i][0] ];
     }
 
-    /* Header */
-    nTrs = oSettings.nTHead.getElementsByTagName('tr');
-    for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+    /* Fixed sorting */
+    if ( oSettings.aaSortingFixed !== null )
     {
-      fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+      for ( i=0, iLen=oSettings.aaSortingFixed.length ; i<iLen ; i++ )
+      {
+        oSettings.aaSortingFixed[i][0] = aiInvertMapping[ oSettings.aaSortingFixed[i][0] ];
+      }
     }
 
-    /* Footer */
-    if ( oSettings.nTFoot !== null )
+    /* Data column sorting (the column which the sort for a given column should take place on) */
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
     {
-      nTrs = oSettings.nTFoot.getElementsByTagName('tr');
+      oCol = oSettings.aoColumns[i];
+      for ( j=0, jLen=oCol.aDataSort.length ; j<jLen ; j++ )
+      {
+        oCol.aDataSort[j] = aiInvertMapping[ oCol.aDataSort[j] ];
+      }
+
+      // Update the column indexes
+      if ( v110 ) {
+        oCol.idx = aiInvertMapping[ oCol.idx ];
+      }
+    }
+
+    if ( v110 ) {
+      // Update 1.10 optimised sort class removal variable
+      $.each( oSettings.aLastSort, function (i, val) {
+        oSettings.aLastSort[i].src = aiInvertMapping[ val.src ];
+      } );
+    }
+
+    /* Update the Get and Set functions for each column */
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
+    {
+      oCol = oSettings.aoColumns[i];
+
+      if ( typeof oCol.mData == 'number' ) {
+        oCol.mData = aiInvertMapping[ oCol.mData ];
+
+        // regenerate the get / set functions
+        oSettings.oApi._fnColumnOptions( oSettings, i, {} );
+      }
+      else if ( $.isPlainObject( oCol.mData ) ) {
+        // HTML5 data sourced
+        attrMap( oCol.mData, '_',      aiInvertMapping );
+        attrMap( oCol.mData, 'filter', aiInvertMapping );
+        attrMap( oCol.mData, 'sort',   aiInvertMapping );
+        attrMap( oCol.mData, 'type',   aiInvertMapping );
+
+        // regenerate the get / set functions
+        oSettings.oApi._fnColumnOptions( oSettings, i, {} );
+      }
+    }
+
+
+    /*
+     * Move the DOM elements
+     */
+    if ( oSettings.aoColumns[iFrom].bVisible )
+    {
+      /* Calculate the current visible index and the point to insert the node before. The insert
+       * before needs to take into account that there might not be an element to insert before,
+       * in which case it will be null, and an appendChild should be used
+       */
+      var iVisibleIndex = this.oApi._fnColumnIndexToVisible( oSettings, iFrom );
+      var iInsertBeforeIndex = null;
+
+      i = iTo < iFrom ? iTo : iTo + 1;
+      while ( iInsertBeforeIndex === null && i < iCols )
+      {
+        iInsertBeforeIndex = this.oApi._fnColumnIndexToVisible( oSettings, i );
+        i++;
+      }
+
+      /* Header */
+      nTrs = oSettings.nTHead.getElementsByTagName('tr');
       for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
       {
         fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
       }
+
+      /* Footer */
+      if ( oSettings.nTFoot !== null )
+      {
+        nTrs = oSettings.nTFoot.getElementsByTagName('tr');
+        for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+        {
+          fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+        }
+      }
+
+      /* Body */
+      for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
+      {
+        if ( oSettings.aoData[i].nTr !== null )
+        {
+          fnDomSwitch( oSettings.aoData[i].nTr, iVisibleIndex, iInsertBeforeIndex );
+        }
+      }
     }
 
-    /* Body */
+    /*
+     * Move the internal array elements
+     */
+    /* Columns */
+    fnArraySwitch( oSettings.aoColumns, iFrom, iTo );
+
+    /* Search columns */
+    fnArraySwitch( oSettings.aoPreSearchCols, iFrom, iTo );
+
+    /* Array array - internal data anodes cache */
     for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
     {
-      if ( oSettings.aoData[i].nTr !== null )
-      {
-        fnDomSwitch( oSettings.aoData[i].nTr, iVisibleIndex, iInsertBeforeIndex );
+      var data = oSettings.aoData[i];
+
+      if ( v110 ) {
+        // DataTables 1.10+
+        if ( data.anCells ) {
+          fnArraySwitch( data.anCells, iFrom, iTo );
+        }
+
+        // For DOM sourced data, the invalidate will reread the cell into
+        // the data array, but for data sources as an array, they need to
+        // be flipped
+        if ( data.src !== 'dom' && $.isArray( data._aData ) ) {
+          fnArraySwitch( data._aData, iFrom, iTo );
+        }
+      }
+      else {
+        // DataTables 1.9-
+        if ( $.isArray( data._aData ) ) {
+          fnArraySwitch( data._aData, iFrom, iTo );
+        }
+        fnArraySwitch( data._anHidden, iFrom, iTo );
       }
     }
-  }
 
-  /*
-   * Move the internal array elements
-   */
-  /* Columns */
-  fnArraySwitch( oSettings.aoColumns, iFrom, iTo );
+    /* Reposition the header elements in the header layout array */
+    for ( i=0, iLen=oSettings.aoHeader.length ; i<iLen ; i++ )
+    {
+      fnArraySwitch( oSettings.aoHeader[i], iFrom, iTo );
+    }
 
-  /* Search columns */
-  fnArraySwitch( oSettings.aoPreSearchCols, iFrom, iTo );
-
-  /* Array array - internal data anodes cache */
-  for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
-  {
-    var data = oSettings.aoData[i];
-
-    if ( v110 ) {
-      // DataTables 1.10+
-      if ( data.anCells ) {
-        fnArraySwitch( data.anCells, iFrom, iTo );
+    if ( oSettings.aoFooter !== null )
+    {
+      for ( i=0, iLen=oSettings.aoFooter.length ; i<iLen ; i++ )
+      {
+        fnArraySwitch( oSettings.aoFooter[i], iFrom, iTo );
       }
+    }
 
-      // For DOM sourced data, the invalidate will reread the cell into
-      // the data array, but for data sources as an array, they need to
-      // be flipped
-      if ( data.src !== 'dom' && $.isArray( data._aData ) ) {
-        fnArraySwitch( data._aData, iFrom, iTo );
+    // In 1.10 we need to invalidate row cached data for sorting, filtering etc
+    if ( v110 ) {
+      var api = new $.fn.dataTable.Api( oSettings );
+      api.rows().invalidate();
+    }
+
+    /*
+     * Update DataTables' event handlers
+     */
+
+    /* Sort listener */
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
+    {
+      $(oSettings.aoColumns[i].nTh).off('click.DT');
+      this.oApi._fnSortAttachListener( oSettings, oSettings.aoColumns[i].nTh, i );
+    }
+
+
+    /* Fire an event so other plug-ins can update */
+    $(oSettings.oInstance).trigger( 'column-reorder', [ oSettings, {
+      "iFrom": iFrom,
+      "iTo": iTo,
+      "aiInvertMapping": aiInvertMapping
+    } ] );
+  };
+
+
+  /**
+   * ColReorder provides column visibility control for DataTables
+   * @class ColReorder
+   * @constructor
+   * @param {object} dt DataTables settings object
+   * @param {object} opts ColReorder options
+   */
+  var ColReorder = function( dt, opts )
+  {
+    var oDTSettings;
+
+    if ( $.fn.dataTable.Api ) {
+      oDTSettings = new $.fn.dataTable.Api( dt ).settings()[0];
+    }
+    // 1.9 compatibility
+    else if ( dt.fnSettings ) {
+      // DataTables object, convert to the settings object
+      oDTSettings = dt.fnSettings();
+    }
+    else if ( typeof dt === 'string' ) {
+      // jQuery selector
+      if ( $.fn.dataTable.fnIsDataTable( $(dt)[0] ) ) {
+        oDTSettings = $(dt).eq(0).dataTable().fnSettings();
+      }
+    }
+    else if ( dt.nodeName && dt.nodeName.toLowerCase() === 'table' ) {
+      // Table node
+      if ( $.fn.dataTable.fnIsDataTable( dt.nodeName ) ) {
+        oDTSettings = $(dt.nodeName).dataTable().fnSettings();
+      }
+    }
+    else if ( dt instanceof jQuery ) {
+      // jQuery object
+      if ( $.fn.dataTable.fnIsDataTable( dt[0] ) ) {
+        oDTSettings = dt.eq(0).dataTable().fnSettings();
       }
     }
     else {
-      // DataTables 1.9-
-      if ( $.isArray( data._aData ) ) {
-        fnArraySwitch( data._aData, iFrom, iTo );
-      }
-      fnArraySwitch( data._anHidden, iFrom, iTo );
-    }
-  }
-
-  /* Reposition the header elements in the header layout array */
-  for ( i=0, iLen=oSettings.aoHeader.length ; i<iLen ; i++ )
-  {
-    fnArraySwitch( oSettings.aoHeader[i], iFrom, iTo );
-  }
-
-  if ( oSettings.aoFooter !== null )
-  {
-    for ( i=0, iLen=oSettings.aoFooter.length ; i<iLen ; i++ )
-    {
-      fnArraySwitch( oSettings.aoFooter[i], iFrom, iTo );
-    }
-  }
-
-  // In 1.10 we need to invalidate row cached data for sorting, filtering etc
-  if ( v110 ) {
-    var api = new $.fn.dataTable.Api( oSettings );
-    api.rows().invalidate();
-  }
-
-  /*
-   * Update DataTables' event handlers
-   */
-
-  /* Sort listener */
-  for ( i=0, iLen=iCols ; i<iLen ; i++ )
-  {
-    $(oSettings.aoColumns[i].nTh).off('click.DT');
-    this.oApi._fnSortAttachListener( oSettings, oSettings.aoColumns[i].nTh, i );
-  }
-
-
-  /* Fire an event so other plug-ins can update */
-  $(oSettings.oInstance).trigger( 'column-reorder', [ oSettings, {
-    "iFrom": iFrom,
-    "iTo": iTo,
-    "aiInvertMapping": aiInvertMapping
-  } ] );
-};
-
-
-/**
- * ColReorder provides column visibility control for DataTables
- * @class ColReorder
- * @constructor
- * @param {object} dt DataTables settings object
- * @param {object} opts ColReorder options
- */
-var ColReorder = function( dt, opts )
-{
-  var oDTSettings;
-
-  if ( $.fn.dataTable.Api ) {
-    oDTSettings = new $.fn.dataTable.Api( dt ).settings()[0];
-  }
-  // 1.9 compatibility
-  else if ( dt.fnSettings ) {
-    // DataTables object, convert to the settings object
-    oDTSettings = dt.fnSettings();
-  }
-  else if ( typeof dt === 'string' ) {
-    // jQuery selector
-    if ( $.fn.dataTable.fnIsDataTable( $(dt)[0] ) ) {
-      oDTSettings = $(dt).eq(0).dataTable().fnSettings();
-    }
-  }
-  else if ( dt.nodeName && dt.nodeName.toLowerCase() === 'table' ) {
-    // Table node
-    if ( $.fn.dataTable.fnIsDataTable( dt.nodeName ) ) {
-      oDTSettings = $(dt.nodeName).dataTable().fnSettings();
-    }
-  }
-  else if ( dt instanceof jQuery ) {
-    // jQuery object
-    if ( $.fn.dataTable.fnIsDataTable( dt[0] ) ) {
-      oDTSettings = dt.eq(0).dataTable().fnSettings();
-    }
-  }
-  else {
-    // DataTables settings object
-    oDTSettings = dt;
-  }
-
-  // Ensure that we can't initialise on the same table twice
-  if ( oDTSettings._colReorder ) {
-    throw "ColReorder already initialised on table #"+oDTSettings.nTable.id;
-  }
-
-  // Convert from camelCase to Hungarian, just as DataTables does
-  var camelToHungarian = $.fn.dataTable.camelToHungarian;
-  if ( camelToHungarian ) {
-    camelToHungarian( ColReorder.defaults, ColReorder.defaults, true );
-    camelToHungarian( ColReorder.defaults, opts || {} );
-  }
-
-
-  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * Public class variables
-   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-  /**
-   * @namespace Settings object which contains customisable information for ColReorder instance
-   */
-  this.s = {
-    /**
-     * DataTables settings object
-     *  @property dt
-     *  @type     Object
-     *  @default  null
-     */
-    "dt": null,
-
-    /**
-     * Initialisation object used for this instance
-     *  @property init
-     *  @type     object
-     *  @default  {}
-     */
-    "init": $.extend( true, {}, ColReorder.defaults, opts ),
-
-    /**
-     * Number of columns to fix (not allow to be reordered)
-     *  @property fixed
-     *  @type     int
-     *  @default  0
-     */
-    "fixed": 0,
-
-    /**
-     * Number of columns to fix counting from right (not allow to be reordered)
-     *  @property fixedRight
-     *  @type     int
-     *  @default  0
-     */
-    "fixedRight": 0,
-
-    /**
-     * Callback function for once the reorder has been done
-     *  @property dropcallback
-     *  @type     function
-     *  @default  null
-     */
-    "dropCallback": null,
-
-    /**
-     * @namespace Information used for the mouse drag
-     */
-    "mouse": {
-      "startX": -1,
-      "startY": -1,
-      "offsetX": -1,
-      "offsetY": -1,
-      "target": -1,
-      "targetIndex": -1,
-      "fromIndex": -1
-    },
-
-    /**
-     * Information which is used for positioning the insert cusor and knowing where to do the
-     * insert. Array of objects with the properties:
-     *   x: x-axis position
-     *   to: insert point
-     *  @property aoTargets
-     *  @type     array
-     *  @default  []
-     */
-    "aoTargets": []
-  };
-
-
-  /**
-   * @namespace Common and useful DOM elements for the class instance
-   */
-  this.dom = {
-    /**
-     * Dragging element (the one the mouse is moving)
-     *  @property drag
-     *  @type     element
-     *  @default  null
-     */
-    "drag": null,
-
-    /**
-     * The insert cursor
-     *  @property pointer
-     *  @type     element
-     *  @default  null
-     */
-    "pointer": null
-  };
-
-
-  /* Constructor logic */
-  this.s.dt = oDTSettings;
-  this.s.dt._colReorder = this;
-  this._fnConstruct();
-
-  /* Add destroy callback */
-  oDTSettings.oApi._fnCallbackReg(oDTSettings, 'aoDestroyCallback', $.proxy(this._fnDestroy, this), 'ColReorder');
-
-  return this;
-};
-
-
-
-ColReorder.prototype = {
-  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * Public methods
-   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-  /**
-   * Reset the column ordering to the original ordering that was detected on
-   * start up.
-   *  @return {this} Returns `this` for chaining.
-   *
-   *  @example
-   *    // DataTables initialisation with ColReorder
-   *    var table = $('#example').dataTable( {
-   *        "sDom": 'Rlfrtip'
-   *    } );
-   *
-   *    // Add click event to a button to reset the ordering
-   *    $('#resetOrdering').click( function (e) {
-   *        e.preventDefault();
-   *        $.fn.dataTable.ColReorder( table ).fnReset();
-   *    } );
-   */
-  "fnReset": function ()
-  {
-    var a = [];
-    for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
-    {
-      a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
+      // DataTables settings object
+      oDTSettings = dt;
     }
 
-    this._fnOrderColumns( a );
+    // Ensure that we can't initialise on the same table twice
+    if ( oDTSettings._colReorder ) {
+      throw "ColReorder already initialised on table #"+oDTSettings.nTable.id;
+    }
+
+    // Convert from camelCase to Hungarian, just as DataTables does
+    var camelToHungarian = $.fn.dataTable.camelToHungarian;
+    if ( camelToHungarian ) {
+      camelToHungarian( ColReorder.defaults, ColReorder.defaults, true );
+      camelToHungarian( ColReorder.defaults, opts || {} );
+    }
+
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Public class variables
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /**
+     * @namespace Settings object which contains customisable information for ColReorder instance
+     */
+    this.s = {
+      /**
+       * DataTables settings object
+       *  @property dt
+       *  @type     Object
+       *  @default  null
+       */
+      "dt": null,
+
+      /**
+       * Initialisation object used for this instance
+       *  @property init
+       *  @type     object
+       *  @default  {}
+       */
+      "init": $.extend( true, {}, ColReorder.defaults, opts ),
+
+      /**
+       * Number of columns to fix (not allow to be reordered)
+       *  @property fixed
+       *  @type     int
+       *  @default  0
+       */
+      "fixed": 0,
+
+      /**
+       * Number of columns to fix counting from right (not allow to be reordered)
+       *  @property fixedRight
+       *  @type     int
+       *  @default  0
+       */
+      "fixedRight": 0,
+
+      /**
+       * Callback function for once the reorder has been done
+       *  @property dropcallback
+       *  @type     function
+       *  @default  null
+       */
+      "dropCallback": null,
+
+      /**
+       * @namespace Information used for the mouse drag
+       */
+      "mouse": {
+        "startX": -1,
+        "startY": -1,
+        "offsetX": -1,
+        "offsetY": -1,
+        "target": -1,
+        "targetIndex": -1,
+        "fromIndex": -1
+      },
+
+      /**
+       * Information which is used for positioning the insert cusor and knowing where to do the
+       * insert. Array of objects with the properties:
+       *   x: x-axis position
+       *   to: insert point
+       *  @property aoTargets
+       *  @type     array
+       *  @default  []
+       */
+      "aoTargets": []
+    };
+
+
+    /**
+     * @namespace Common and useful DOM elements for the class instance
+     */
+    this.dom = {
+      /**
+       * Dragging element (the one the mouse is moving)
+       *  @property drag
+       *  @type     element
+       *  @default  null
+       */
+      "drag": null,
+
+      /**
+       * The insert cursor
+       *  @property pointer
+       *  @type     element
+       *  @default  null
+       */
+      "pointer": null
+    };
+
+
+    /* Constructor logic */
+    this.s.dt = oDTSettings;
+    this.s.dt._colReorder = this;
+    this._fnConstruct();
+
+    /* Add destroy callback */
+    oDTSettings.oApi._fnCallbackReg(oDTSettings, 'aoDestroyCallback', $.proxy(this._fnDestroy, this), 'ColReorder');
 
     return this;
-  },
+  };
 
-  /**
-   * `Deprecated` - Get the current order of the columns, as an array.
-   *  @return {array} Array of column identifiers
-   *  @deprecated `fnOrder` should be used in preference to this method.
-   *      `fnOrder` acts as a getter/setter.
-   */
-  "fnGetCurrentOrder": function ()
-  {
-    return this.fnOrder();
-  },
 
-  /**
-   * Get the current order of the columns, as an array. Note that the values
-   * given in the array are unique identifiers for each column. Currently
-   * these are the original ordering of the columns that was detected on
-   * start up, but this could potentially change in future.
-   *  @return {array} Array of column identifiers
-   *
-   *  @example
-   *    // Get column ordering for the table
-   *    var order = $.fn.dataTable.ColReorder( dataTable ).fnOrder();
-   *//**
-   * Set the order of the columns, from the positions identified in the
-   * ordering array given. Note that ColReorder takes a brute force approach
-   * to reordering, so it is possible multiple reordering events will occur
-   * before the final order is settled upon.
-   *  @param {array} [set] Array of column identifiers in the new order. Note
-   *    that every column must be included, uniquely, in this array.
-   *  @return {this} Returns `this` for chaining.
-   *
-   *  @example
-   *    // Swap the first and second columns
-   *    $.fn.dataTable.ColReorder( dataTable ).fnOrder( [1, 0, 2, 3, 4] );
-   *
-   *  @example
-   *    // Move the first column to the end for the table `#example`
-   *    var curr = $.fn.dataTable.ColReorder( '#example' ).fnOrder();
-   *    var first = curr.shift();
-   *    curr.push( first );
-   *    $.fn.dataTable.ColReorder( '#example' ).fnOrder( curr );
-   *
-   *  @example
-   *    // Reverse the table's order
-   *    $.fn.dataTable.ColReorder( '#example' ).fnOrder(
-   *      $.fn.dataTable.ColReorder( '#example' ).fnOrder().reverse()
-   *    );
-   */
-  "fnOrder": function ( set )
-  {
-    if ( set === undefined )
+
+  ColReorder.prototype = {
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Public methods
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /**
+     * Reset the column ordering to the original ordering that was detected on
+     * start up.
+     *  @return {this} Returns `this` for chaining.
+     *
+     *  @example
+     *    // DataTables initialisation with ColReorder
+     *    var table = $('#example').dataTable( {
+     *        "sDom": 'Rlfrtip'
+     *    } );
+     *
+     *    // Add click event to a button to reset the ordering
+     *    $('#resetOrdering').click( function (e) {
+     *        e.preventDefault();
+     *        $.fn.dataTable.ColReorder( table ).fnReset();
+     *    } );
+     */
+    "fnReset": function ()
     {
       var a = [];
       for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
       {
         a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
       }
-      return a;
-    }
 
-    this._fnOrderColumns( fnInvertKeyValues( set ) );
+      this._fnOrderColumns( a );
 
-    return this;
-  },
+      return this;
+    },
 
-
-  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * Private methods (they are of course public in JS, but recommended as private)
-   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-  /**
-   * Constructor logic
-   *  @method  _fnConstruct
-   *  @returns void
-   *  @private
-   */
-  "_fnConstruct": function ()
-  {
-    var that = this;
-    var iLen = this.s.dt.aoColumns.length;
-    var i;
-
-    /* Columns discounted from reordering - counting left to right */
-    if ( this.s.init.iFixedColumns )
+    /**
+     * `Deprecated` - Get the current order of the columns, as an array.
+     *  @return {array} Array of column identifiers
+     *  @deprecated `fnOrder` should be used in preference to this method.
+     *      `fnOrder` acts as a getter/setter.
+     */
+    "fnGetCurrentOrder": function ()
     {
-      this.s.fixed = this.s.init.iFixedColumns;
-    }
+      return this.fnOrder();
+    },
 
-    /* Columns discounted from reordering - counting right to left */
-    this.s.fixedRight = this.s.init.iFixedColumnsRight ?
-      this.s.init.iFixedColumnsRight :
-      0;
-
-    /* Drop callback initialisation option */
-    if ( this.s.init.fnReorderCallback )
+    /**
+     * Get the current order of the columns, as an array. Note that the values
+     * given in the array are unique identifiers for each column. Currently
+     * these are the original ordering of the columns that was detected on
+     * start up, but this could potentially change in future.
+     *  @return {array} Array of column identifiers
+     *
+     *  @example
+     *    // Get column ordering for the table
+     *    var order = $.fn.dataTable.ColReorder( dataTable ).fnOrder();
+     *//**
+     * Set the order of the columns, from the positions identified in the
+     * ordering array given. Note that ColReorder takes a brute force approach
+     * to reordering, so it is possible multiple reordering events will occur
+     * before the final order is settled upon.
+     *  @param {array} [set] Array of column identifiers in the new order. Note
+     *    that every column must be included, uniquely, in this array.
+     *  @return {this} Returns `this` for chaining.
+     *
+     *  @example
+     *    // Swap the first and second columns
+     *    $.fn.dataTable.ColReorder( dataTable ).fnOrder( [1, 0, 2, 3, 4] );
+     *
+     *  @example
+     *    // Move the first column to the end for the table `#example`
+     *    var curr = $.fn.dataTable.ColReorder( '#example' ).fnOrder();
+     *    var first = curr.shift();
+     *    curr.push( first );
+     *    $.fn.dataTable.ColReorder( '#example' ).fnOrder( curr );
+     *
+     *  @example
+     *    // Reverse the table's order
+     *    $.fn.dataTable.ColReorder( '#example' ).fnOrder(
+     *      $.fn.dataTable.ColReorder( '#example' ).fnOrder().reverse()
+     *    );
+     */
+    "fnOrder": function ( set )
     {
-      this.s.dropCallback = this.s.init.fnReorderCallback;
-    }
-
-    /* Add event handlers for the drag and drop, and also mark the original column order */
-    for ( i = 0; i < iLen; i++ )
-    {
-      if ( i > this.s.fixed-1 && i < iLen - this.s.fixedRight )
+      if ( set === undefined )
       {
-        this._fnMouseListener( i, this.s.dt.aoColumns[i].nTh );
+        var a = [];
+        for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
+        {
+          a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
+        }
+        return a;
       }
 
-      /* Mark the original column order for later reference */
-      this.s.dt.aoColumns[i]._ColReorder_iOrigCol = i;
-    }
+      this._fnOrderColumns( fnInvertKeyValues( set ) );
 
-    /* State saving */
-    this.s.dt.oApi._fnCallbackReg( this.s.dt, 'aoStateSaveParams', function (oS, oData) {
-      that._fnStateSave.call( that, oData );
-    }, "ColReorder_State" );
+      return this;
+    },
 
-    /* An initial column order has been specified */
-    var aiOrder = null;
-    if ( this.s.init.aiOrder )
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Private methods (they are of course public in JS, but recommended as private)
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /**
+     * Constructor logic
+     *  @method  _fnConstruct
+     *  @returns void
+     *  @private
+     */
+    "_fnConstruct": function ()
     {
-      aiOrder = this.s.init.aiOrder.slice();
-    }
+      var that = this;
+      var iLen = this.s.dt.aoColumns.length;
+      var i;
 
-    /* State loading, overrides the column order given */
-    if ( this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
-      this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length )
-    {
-      aiOrder = this.s.dt.oLoadedState.ColReorder;
-    }
-
-    /* If we have an order to apply - do so */
-    if ( aiOrder )
-    {
-      /* We might be called during or after the DataTables initialisation. If before, then we need
-       * to wait until the draw is done, if after, then do what we need to do right away
-       */
-      if ( !that.s.dt._bInitComplete )
+      /* Columns discounted from reordering - counting left to right */
+      if ( this.s.init.iFixedColumns )
       {
-        var bDone = false;
-        this.s.dt.aoDrawCallback.push( {
-          "fn": function () {
-            if ( !that.s.dt._bInitComplete && !bDone )
-            {
-              bDone = true;
-              var resort = fnInvertKeyValues( aiOrder );
-              that._fnOrderColumns.call( that, resort );
-            }
-          },
-          "sName": "ColReorder_Pre"
-        } );
+        this.s.fixed = this.s.init.iFixedColumns;
       }
-      else
+
+      /* Columns discounted from reordering - counting right to left */
+      this.s.fixedRight = this.s.init.iFixedColumnsRight ?
+        this.s.init.iFixedColumnsRight :
+        0;
+
+      /* Drop callback initialisation option */
+      if ( this.s.init.fnReorderCallback )
       {
-        var resort = fnInvertKeyValues( aiOrder );
-        that._fnOrderColumns.call( that, resort );
+        this.s.dropCallback = this.s.init.fnReorderCallback;
       }
-    }
-    else {
-      this._fnSetColumnIndexes();
-    }
-  },
+
+      /* Add event handlers for the drag and drop, and also mark the original column order */
+      for ( i = 0; i < iLen; i++ )
+      {
+        if ( i > this.s.fixed-1 && i < iLen - this.s.fixedRight )
+        {
+          this._fnMouseListener( i, this.s.dt.aoColumns[i].nTh );
+        }
+
+        /* Mark the original column order for later reference */
+        this.s.dt.aoColumns[i]._ColReorder_iOrigCol = i;
+      }
+
+      /* State saving */
+      this.s.dt.oApi._fnCallbackReg( this.s.dt, 'aoStateSaveParams', function (oS, oData) {
+        that._fnStateSave.call( that, oData );
+      }, "ColReorder_State" );
+
+      /* An initial column order has been specified */
+      var aiOrder = null;
+      if ( this.s.init.aiOrder )
+      {
+        aiOrder = this.s.init.aiOrder.slice();
+      }
+
+      /* State loading, overrides the column order given */
+      if ( this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
+        this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length )
+      {
+        aiOrder = this.s.dt.oLoadedState.ColReorder;
+      }
+
+      /* If we have an order to apply - do so */
+      if ( aiOrder )
+      {
+        /* We might be called during or after the DataTables initialisation. If before, then we need
+         * to wait until the draw is done, if after, then do what we need to do right away
+         */
+        if ( !that.s.dt._bInitComplete )
+        {
+          var bDone = false;
+          this.s.dt.aoDrawCallback.push( {
+            "fn": function () {
+              if ( !that.s.dt._bInitComplete && !bDone )
+              {
+                bDone = true;
+                var resort = fnInvertKeyValues( aiOrder );
+                that._fnOrderColumns.call( that, resort );
+              }
+            },
+            "sName": "ColReorder_Pre"
+          } );
+        }
+        else
+        {
+          var resort = fnInvertKeyValues( aiOrder );
+          that._fnOrderColumns.call( that, resort );
+        }
+      }
+      else {
+        this._fnSetColumnIndexes();
+      }
+    },
 
 
-  /**
-   * Set the column order from an array
-   *  @method  _fnOrderColumns
-   *  @param   array a An array of integers which dictate the column order that should be applied
-   *  @returns void
-   *  @private
-   */
-  "_fnOrderColumns": function ( a )
-  {
-    if ( a.length != this.s.dt.aoColumns.length )
+    /**
+     * Set the column order from an array
+     *  @method  _fnOrderColumns
+     *  @param   array a An array of integers which dictate the column order that should be applied
+     *  @returns void
+     *  @private
+     */
+    "_fnOrderColumns": function ( a )
     {
-      this.s.dt.oInstance.oApi._fnLog( this.s.dt, 1, "ColReorder - array reorder does not "+
-        "match known number of columns. Skipping." );
-      return;
-    }
-
-    for ( var i=0, iLen=a.length ; i<iLen ; i++ )
-    {
-      var currIndex = $.inArray( i, a );
-      if ( i != currIndex )
+      if ( a.length != this.s.dt.aoColumns.length )
       {
-        /* Reorder our switching array */
-        fnArraySwitch( a, currIndex, i );
-
-        /* Do the column reorder in the table */
-        this.s.dt.oInstance.fnColReorder( currIndex, i );
-      }
-    }
-
-    /* When scrolling we need to recalculate the column sizes to allow for the shift */
-    if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
-    {
-      this.s.dt.oInstance.fnAdjustColumnSizing();
-    }
-
-    /* Save the state */
-    this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
-
-    this._fnSetColumnIndexes();
-  },
-
-
-  /**
-   * Because we change the indexes of columns in the table, relative to their starting point
-   * we need to reorder the state columns to what they are at the starting point so we can
-   * then rearrange them again on state load!
-   *  @method  _fnStateSave
-   *  @param   object oState DataTables state
-   *  @returns string JSON encoded cookie string for DataTables
-   *  @private
-   */
-  "_fnStateSave": function ( oState )
-  {
-    var i, iLen, aCopy, iOrigColumn;
-    var oSettings = this.s.dt;
-    var columns = oSettings.aoColumns;
-
-    oState.ColReorder = [];
-
-    /* Sorting */
-    if ( oState.aaSorting ) {
-      // 1.10.0-
-      for ( i=0 ; i<oState.aaSorting.length ; i++ ) {
-        oState.aaSorting[i][0] = columns[ oState.aaSorting[i][0] ]._ColReorder_iOrigCol;
-      }
-
-      var aSearchCopy = $.extend( true, [], oState.aoSearchCols );
-
-      for ( i=0, iLen=columns.length ; i<iLen ; i++ )
-      {
-        iOrigColumn = columns[i]._ColReorder_iOrigCol;
-
-        /* Column filter */
-        oState.aoSearchCols[ iOrigColumn ] = aSearchCopy[i];
-
-        /* Visibility */
-        oState.abVisCols[ iOrigColumn ] = columns[i].bVisible;
-
-        /* Column reordering */
-        oState.ColReorder.push( iOrigColumn );
-      }
-    }
-    else if ( oState.order ) {
-      // 1.10.1+
-      for ( i=0 ; i<oState.order.length ; i++ ) {
-        oState.order[i][0] = columns[ oState.order[i][0] ]._ColReorder_iOrigCol;
-      }
-
-      var stateColumnsCopy = $.extend( true, [], oState.columns );
-
-      for ( i=0, iLen=columns.length ; i<iLen ; i++ )
-      {
-        iOrigColumn = columns[i]._ColReorder_iOrigCol;
-
-        /* Columns */
-        oState.columns[ iOrigColumn ] = stateColumnsCopy[i];
-
-        /* Column reordering */
-        oState.ColReorder.push( iOrigColumn );
-      }
-    }
-  },
-
-
-  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * Mouse drop and drag
-   */
-
-  /**
-   * Add a mouse down listener to a particluar TH element
-   *  @method  _fnMouseListener
-   *  @param   int i Column index
-   *  @param   element nTh TH element clicked on
-   *  @returns void
-   *  @private
-   */
-  "_fnMouseListener": function ( i, nTh )
-  {
-    var that = this;
-    $(nTh).on( 'mousedown.ColReorder', function (e) {
-      e.preventDefault();
-      that._fnMouseDown.call( that, e, nTh );
-    } );
-  },
-
-
-  /**
-   * Mouse down on a TH element in the table header
-   *  @method  _fnMouseDown
-   *  @param   event e Mouse event
-   *  @param   element nTh TH element to be dragged
-   *  @returns void
-   *  @private
-   */
-  "_fnMouseDown": function ( e, nTh )
-  {
-    var that = this;
-
-    /* Store information about the mouse position */
-    var target = $(e.target).closest('th, td');
-    var offset = target.offset();
-    var idx = parseInt( $(nTh).attr('data-column-index'), 10 );
-
-    if ( idx === undefined ) {
-      return;
-    }
-
-    this.s.mouse.startX = e.pageX;
-    this.s.mouse.startY = e.pageY;
-    this.s.mouse.offsetX = e.pageX - offset.left;
-    this.s.mouse.offsetY = e.pageY - offset.top;
-    this.s.mouse.target = this.s.dt.aoColumns[ idx ].nTh;//target[0];
-    this.s.mouse.targetIndex = idx;
-    this.s.mouse.fromIndex = idx;
-
-    this._fnRegions();
-
-    /* Add event handlers to the document */
-    $(document)
-      .on( 'mousemove.ColReorder', function (e) {
-        that._fnMouseMove.call( that, e );
-      } )
-      .on( 'mouseup.ColReorder', function (e) {
-        that._fnMouseUp.call( that, e );
-      } );
-  },
-
-
-  /**
-   * Deal with a mouse move event while dragging a node
-   *  @method  _fnMouseMove
-   *  @param   event e Mouse event
-   *  @returns void
-   *  @private
-   */
-  "_fnMouseMove": function ( e )
-  {
-    var that = this;
-
-    if ( this.dom.drag === null )
-    {
-      /* Only create the drag element if the mouse has moved a specific distance from the start
-       * point - this allows the user to make small mouse movements when sorting and not have a
-       * possibly confusing drag element showing up
-       */
-      if ( Math.pow(
-        Math.pow(e.pageX - this.s.mouse.startX, 2) +
-        Math.pow(e.pageY - this.s.mouse.startY, 2), 0.5 ) < 5 )
-      {
+        this.s.dt.oInstance.oApi._fnLog( this.s.dt, 1, "ColReorder - array reorder does not "+
+          "match known number of columns. Skipping." );
         return;
       }
-      this._fnCreateDragNode();
-    }
 
-    /* Position the element - we respect where in the element the click occured */
-    this.dom.drag.css( {
-      left: e.pageX - this.s.mouse.offsetX,
-      top: e.pageY - this.s.mouse.offsetY
-    } );
-
-    /* Based on the current mouse position, calculate where the insert should go */
-    var bSet = false;
-    var lastToIndex = this.s.mouse.toIndex;
-
-    for ( var i=1, iLen=this.s.aoTargets.length ; i<iLen ; i++ )
-    {
-      if ( e.pageX < this.s.aoTargets[i-1].x + ((this.s.aoTargets[i].x-this.s.aoTargets[i-1].x)/2) )
+      for ( var i=0, iLen=a.length ; i<iLen ; i++ )
       {
-        this.dom.pointer.css( 'left', this.s.aoTargets[i-1].x );
-        this.s.mouse.toIndex = this.s.aoTargets[i-1].to;
-        bSet = true;
-        break;
+        var currIndex = $.inArray( i, a );
+        if ( i != currIndex )
+        {
+          /* Reorder our switching array */
+          fnArraySwitch( a, currIndex, i );
+
+          /* Do the column reorder in the table */
+          this.s.dt.oInstance.fnColReorder( currIndex, i );
+        }
       }
-    }
-
-    // The insert element wasn't positioned in the array (less than
-    // operator), so we put it at the end
-    if ( !bSet )
-    {
-      this.dom.pointer.css( 'left', this.s.aoTargets[this.s.aoTargets.length-1].x );
-      this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length-1].to;
-    }
-
-    // Perform reordering if realtime updating is on and the column has moved
-    if ( this.s.init.bRealtime && lastToIndex !== this.s.mouse.toIndex ) {
-      this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
-      this.s.mouse.fromIndex = this.s.mouse.toIndex;
-      this._fnRegions();
-    }
-  },
-
-
-  /**
-   * Finish off the mouse drag and insert the column where needed
-   *  @method  _fnMouseUp
-   *  @param   event e Mouse event
-   *  @returns void
-   *  @private
-   */
-  "_fnMouseUp": function ( e )
-  {
-    var that = this;
-
-    $(document).off( 'mousemove.ColReorder mouseup.ColReorder' );
-
-    if ( this.dom.drag !== null )
-    {
-      /* Remove the guide elements */
-      this.dom.drag.remove();
-      this.dom.pointer.remove();
-      this.dom.drag = null;
-      this.dom.pointer = null;
-
-      /* Actually do the reorder */
-      this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
-      this._fnSetColumnIndexes();
 
       /* When scrolling we need to recalculate the column sizes to allow for the shift */
       if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
@@ -2967,408 +2739,637 @@ ColReorder.prototype = {
         this.s.dt.oInstance.fnAdjustColumnSizing();
       }
 
-      if ( this.s.dropCallback !== null )
-      {
-        this.s.dropCallback.call( this, this.s.mouse.fromIndex, this.s.mouse.toIndex );
-      }
-
       /* Save the state */
       this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
-    }
-  },
+
+      this._fnSetColumnIndexes();
+    },
 
 
-  /**
-   * Calculate a cached array with the points of the column inserts, and the
-   * 'to' points
-   *  @method  _fnRegions
-   *  @returns void
-   *  @private
-   */
-  "_fnRegions": function ()
-  {
-    var aoColumns = this.s.dt.aoColumns;
-
-    this.s.aoTargets.splice( 0, this.s.aoTargets.length );
-
-    this.s.aoTargets.push( {
-      "x":  $(this.s.dt.nTable).offset().left,
-      "to": 0
-    } );
-
-    var iToPoint = 0;
-    for ( var i=0, iLen=aoColumns.length ; i<iLen ; i++ )
+    /**
+     * Because we change the indexes of columns in the table, relative to their starting point
+     * we need to reorder the state columns to what they are at the starting point so we can
+     * then rearrange them again on state load!
+     *  @method  _fnStateSave
+     *  @param   object oState DataTables state
+     *  @returns string JSON encoded cookie string for DataTables
+     *  @private
+     */
+    "_fnStateSave": function ( oState )
     {
-      /* For the column / header in question, we want it's position to remain the same if the
-       * position is just to it's immediate left or right, so we only incremement the counter for
-       * other columns
-       */
-      if ( i != this.s.mouse.fromIndex )
-      {
-        iToPoint++;
+      var i, iLen, aCopy, iOrigColumn;
+      var oSettings = this.s.dt;
+      var columns = oSettings.aoColumns;
+
+      oState.ColReorder = [];
+
+      /* Sorting */
+      if ( oState.aaSorting ) {
+        // 1.10.0-
+        for ( i=0 ; i<oState.aaSorting.length ; i++ ) {
+          oState.aaSorting[i][0] = columns[ oState.aaSorting[i][0] ]._ColReorder_iOrigCol;
+        }
+
+        var aSearchCopy = $.extend( true, [], oState.aoSearchCols );
+
+        for ( i=0, iLen=columns.length ; i<iLen ; i++ )
+        {
+          iOrigColumn = columns[i]._ColReorder_iOrigCol;
+
+          /* Column filter */
+          oState.aoSearchCols[ iOrigColumn ] = aSearchCopy[i];
+
+          /* Visibility */
+          oState.abVisCols[ iOrigColumn ] = columns[i].bVisible;
+
+          /* Column reordering */
+          oState.ColReorder.push( iOrigColumn );
+        }
+      }
+      else if ( oState.order ) {
+        // 1.10.1+
+        for ( i=0 ; i<oState.order.length ; i++ ) {
+          oState.order[i][0] = columns[ oState.order[i][0] ]._ColReorder_iOrigCol;
+        }
+
+        var stateColumnsCopy = $.extend( true, [], oState.columns );
+
+        for ( i=0, iLen=columns.length ; i<iLen ; i++ )
+        {
+          iOrigColumn = columns[i]._ColReorder_iOrigCol;
+
+          /* Columns */
+          oState.columns[ iOrigColumn ] = stateColumnsCopy[i];
+
+          /* Column reordering */
+          oState.ColReorder.push( iOrigColumn );
+        }
+      }
+    },
+
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Mouse drop and drag
+     */
+
+    /**
+     * Add a mouse down listener to a particluar TH element
+     *  @method  _fnMouseListener
+     *  @param   int i Column index
+     *  @param   element nTh TH element clicked on
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseListener": function ( i, nTh )
+    {
+      var that = this;
+      $(nTh).on( 'mousedown.ColReorder', function (e) {
+        e.preventDefault();
+        that._fnMouseDown.call( that, e, nTh );
+      } );
+    },
+
+
+    /**
+     * Mouse down on a TH element in the table header
+     *  @method  _fnMouseDown
+     *  @param   event e Mouse event
+     *  @param   element nTh TH element to be dragged
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseDown": function ( e, nTh )
+    {
+      var that = this;
+
+      /* Store information about the mouse position */
+      var target = $(e.target).closest('th, td');
+      var offset = target.offset();
+      var idx = parseInt( $(nTh).attr('data-column-index'), 10 );
+
+      if ( idx === undefined ) {
+        return;
       }
 
-      if ( aoColumns[i].bVisible )
-      {
-        this.s.aoTargets.push( {
-          "x":  $(aoColumns[i].nTh).offset().left + $(aoColumns[i].nTh).outerWidth(),
-          "to": iToPoint
+      this.s.mouse.startX = e.pageX;
+      this.s.mouse.startY = e.pageY;
+      this.s.mouse.offsetX = e.pageX - offset.left;
+      this.s.mouse.offsetY = e.pageY - offset.top;
+      this.s.mouse.target = this.s.dt.aoColumns[ idx ].nTh;//target[0];
+      this.s.mouse.targetIndex = idx;
+      this.s.mouse.fromIndex = idx;
+
+      this._fnRegions();
+
+      /* Add event handlers to the document */
+      $(document)
+        .on( 'mousemove.ColReorder', function (e) {
+          that._fnMouseMove.call( that, e );
+        } )
+        .on( 'mouseup.ColReorder', function (e) {
+          that._fnMouseUp.call( that, e );
         } );
+    },
+
+
+    /**
+     * Deal with a mouse move event while dragging a node
+     *  @method  _fnMouseMove
+     *  @param   event e Mouse event
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseMove": function ( e )
+    {
+      var that = this;
+
+      if ( this.dom.drag === null )
+      {
+        /* Only create the drag element if the mouse has moved a specific distance from the start
+         * point - this allows the user to make small mouse movements when sorting and not have a
+         * possibly confusing drag element showing up
+         */
+        if ( Math.pow(
+          Math.pow(e.pageX - this.s.mouse.startX, 2) +
+          Math.pow(e.pageY - this.s.mouse.startY, 2), 0.5 ) < 5 )
+        {
+          return;
+        }
+        this._fnCreateDragNode();
       }
-    }
 
-    /* Disallow columns for being reordered by drag and drop, counting right to left */
-    if ( this.s.fixedRight !== 0 )
+      /* Position the element - we respect where in the element the click occured */
+      this.dom.drag.css( {
+        left: e.pageX - this.s.mouse.offsetX,
+        top: e.pageY - this.s.mouse.offsetY
+      } );
+
+      /* Based on the current mouse position, calculate where the insert should go */
+      var bSet = false;
+      var lastToIndex = this.s.mouse.toIndex;
+
+      for ( var i=1, iLen=this.s.aoTargets.length ; i<iLen ; i++ )
+      {
+        if ( e.pageX < this.s.aoTargets[i-1].x + ((this.s.aoTargets[i].x-this.s.aoTargets[i-1].x)/2) )
+        {
+          this.dom.pointer.css( 'left', this.s.aoTargets[i-1].x );
+          this.s.mouse.toIndex = this.s.aoTargets[i-1].to;
+          bSet = true;
+          break;
+        }
+      }
+
+      // The insert element wasn't positioned in the array (less than
+      // operator), so we put it at the end
+      if ( !bSet )
+      {
+        this.dom.pointer.css( 'left', this.s.aoTargets[this.s.aoTargets.length-1].x );
+        this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length-1].to;
+      }
+
+      // Perform reordering if realtime updating is on and the column has moved
+      if ( this.s.init.bRealtime && lastToIndex !== this.s.mouse.toIndex ) {
+        this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
+        this.s.mouse.fromIndex = this.s.mouse.toIndex;
+        this._fnRegions();
+      }
+    },
+
+
+    /**
+     * Finish off the mouse drag and insert the column where needed
+     *  @method  _fnMouseUp
+     *  @param   event e Mouse event
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseUp": function ( e )
     {
-      this.s.aoTargets.splice( this.s.aoTargets.length - this.s.fixedRight );
-    }
+      var that = this;
 
-    /* Disallow columns for being reordered by drag and drop, counting left to right */
-    if ( this.s.fixed !== 0 )
+      $(document).off( 'mousemove.ColReorder mouseup.ColReorder' );
+
+      if ( this.dom.drag !== null )
+      {
+        /* Remove the guide elements */
+        this.dom.drag.remove();
+        this.dom.pointer.remove();
+        this.dom.drag = null;
+        this.dom.pointer = null;
+
+        /* Actually do the reorder */
+        this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
+        this._fnSetColumnIndexes();
+
+        /* When scrolling we need to recalculate the column sizes to allow for the shift */
+        if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
+        {
+          this.s.dt.oInstance.fnAdjustColumnSizing();
+        }
+
+        if ( this.s.dropCallback !== null )
+        {
+          this.s.dropCallback.call( this, this.s.mouse.fromIndex, this.s.mouse.toIndex );
+        }
+
+        /* Save the state */
+        this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
+      }
+    },
+
+
+    /**
+     * Calculate a cached array with the points of the column inserts, and the
+     * 'to' points
+     *  @method  _fnRegions
+     *  @returns void
+     *  @private
+     */
+    "_fnRegions": function ()
     {
-      this.s.aoTargets.splice( 0, this.s.fixed );
-    }
-  },
+      var aoColumns = this.s.dt.aoColumns;
+
+      this.s.aoTargets.splice( 0, this.s.aoTargets.length );
+
+      this.s.aoTargets.push( {
+        "x":  $(this.s.dt.nTable).offset().left,
+        "to": 0
+      } );
+
+      var iToPoint = 0;
+      for ( var i=0, iLen=aoColumns.length ; i<iLen ; i++ )
+      {
+        /* For the column / header in question, we want it's position to remain the same if the
+         * position is just to it's immediate left or right, so we only incremement the counter for
+         * other columns
+         */
+        if ( i != this.s.mouse.fromIndex )
+        {
+          iToPoint++;
+        }
+
+        if ( aoColumns[i].bVisible )
+        {
+          this.s.aoTargets.push( {
+            "x":  $(aoColumns[i].nTh).offset().left + $(aoColumns[i].nTh).outerWidth(),
+            "to": iToPoint
+          } );
+        }
+      }
+
+      /* Disallow columns for being reordered by drag and drop, counting right to left */
+      if ( this.s.fixedRight !== 0 )
+      {
+        this.s.aoTargets.splice( this.s.aoTargets.length - this.s.fixedRight );
+      }
+
+      /* Disallow columns for being reordered by drag and drop, counting left to right */
+      if ( this.s.fixed !== 0 )
+      {
+        this.s.aoTargets.splice( 0, this.s.fixed );
+      }
+    },
 
 
-  /**
-   * Copy the TH element that is being drags so the user has the idea that they are actually
-   * moving it around the page.
-   *  @method  _fnCreateDragNode
-   *  @returns void
-   *  @private
-   */
-  "_fnCreateDragNode": function ()
-  {
-    var scrolling = this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "";
+    /**
+     * Copy the TH element that is being drags so the user has the idea that they are actually
+     * moving it around the page.
+     *  @method  _fnCreateDragNode
+     *  @returns void
+     *  @private
+     */
+    "_fnCreateDragNode": function ()
+    {
+      var scrolling = this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "";
 
-    var origCell = this.s.dt.aoColumns[ this.s.mouse.targetIndex ].nTh;
-    var origTr = origCell.parentNode;
-    var origThead = origTr.parentNode;
-    var origTable = origThead.parentNode;
-    var cloneCell = $(origCell).clone();
+      var origCell = this.s.dt.aoColumns[ this.s.mouse.targetIndex ].nTh;
+      var origTr = origCell.parentNode;
+      var origThead = origTr.parentNode;
+      var origTable = origThead.parentNode;
+      var cloneCell = $(origCell).clone();
 
-    // This is a slightly odd combination of jQuery and DOM, but it is the
-    // fastest and least resource intensive way I could think of cloning
-    // the table with just a single header cell in it.
-    this.dom.drag = $(origTable.cloneNode(false))
-      .addClass( 'DTCR_clonedTable' )
-      .append(
-        origThead.cloneNode(false).appendChild(
-          origTr.cloneNode(false).appendChild(
-            cloneCell[0]
+      // This is a slightly odd combination of jQuery and DOM, but it is the
+      // fastest and least resource intensive way I could think of cloning
+      // the table with just a single header cell in it.
+      this.dom.drag = $(origTable.cloneNode(false))
+        .addClass( 'DTCR_clonedTable' )
+        .append(
+          origThead.cloneNode(false).appendChild(
+            origTr.cloneNode(false).appendChild(
+              cloneCell[0]
+            )
           )
         )
-      )
-      .css( {
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: $(origCell).outerWidth(),
-        height: $(origCell).outerHeight()
-      } )
-      .appendTo( 'body' );
+        .css( {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: $(origCell).outerWidth(),
+          height: $(origCell).outerHeight()
+        } )
+        .appendTo( 'body' );
 
-    this.dom.pointer = $('<div></div>')
-      .addClass( 'DTCR_pointer' )
-      .css( {
-        position: 'absolute',
-        top: scrolling ?
-          $('div.dataTables_scroll', this.s.dt.nTableWrapper).offset().top :
-          $(this.s.dt.nTable).offset().top,
-        height : scrolling ?
-          $('div.dataTables_scroll', this.s.dt.nTableWrapper).height() :
-          $(this.s.dt.nTable).height()
-      } )
-      .appendTo( 'body' );
-  },
-
-  /**
-   * Clean up ColReorder memory references and event handlers
-   *  @method  _fnDestroy
-   *  @returns void
-   *  @private
-   */
-  "_fnDestroy": function ()
-  {
-    var i, iLen;
-
-    for ( i=0, iLen=this.s.dt.aoDrawCallback.length ; i<iLen ; i++ )
-    {
-      if ( this.s.dt.aoDrawCallback[i].sName === 'ColReorder_Pre' )
-      {
-        this.s.dt.aoDrawCallback.splice( i, 1 );
-        break;
-      }
-    }
-
-    $(this.s.dt.nTHead).find( '*' ).off( '.ColReorder' );
-
-    $.each( this.s.dt.aoColumns, function (i, column) {
-      $(column.nTh).removeAttr('data-column-index');
-    } );
-
-    this.s.dt._colReorder = null;
-    this.s = null;
-  },
-
-
-  /**
-   * Add a data attribute to the column headers, so we know the index of
-   * the row to be reordered. This allows fast detection of the index, and
-   * for this plug-in to work with FixedHeader which clones the nodes.
-   *  @private
-   */
-  "_fnSetColumnIndexes": function ()
-  {
-    $.each( this.s.dt.aoColumns, function (i, column) {
-      $(column.nTh).attr('data-column-index', i);
-    } );
-  }
-};
-
-
-
-
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * Static parameters
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-
-/**
- * ColReorder default settings for initialisation
- *  @namespace
- *  @static
- */
-ColReorder.defaults = {
-  /**
-   * Predefined ordering for the columns that will be applied automatically
-   * on initialisation. If not specified then the order that the columns are
-   * found to be in the HTML is the order used.
-   *  @type array
-   *  @default null
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "aiOrder": [ 4, 3, 2, 1, 0 ]
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "aiOrder": [ 4, 3, 2, 1, 0 ]
-   *      } );
-   */
-  aiOrder: null,
-
-  /**
-   * Redraw the table's column ordering as the end user draws the column
-   * (`true`) or wait until the mouse is released (`false` - default). Note
-   * that this will perform a redraw on each reordering, which involves an
-   * Ajax request each time if you are using server-side processing in
-   * DataTables.
-   *  @type boolean
-   *  @default false
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "bRealtime": true
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "bRealtime": true
-   *      } );
-   */
-  bRealtime: false,
-
-  /**
-   * Indicate how many columns should be fixed in position (counting from the
-   * left). This will typically be 1 if used, but can be as high as you like.
-   *  @type int
-   *  @default 0
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "iFixedColumns": 1
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "iFixedColumns": 1
-   *      } );
-   */
-  iFixedColumns: 0,
-
-  /**
-   * As `iFixedColumnsRight` but counting from the right.
-   *  @type int
-   *  @default 0
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "iFixedColumnsRight": 1
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "iFixedColumnsRight": 1
-   *      } );
-   */
-  iFixedColumnsRight: 0,
-
-  /**
-   * Callback function that is fired when columns are reordered
-   *  @type function():void
-   *  @default null
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "fnReorderCallback": function () {
-   *                  alert( 'Columns reordered' );
-   *              }
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "fnReorderCallback": function () {
-   *              alert( 'Columns reordered' );
-   *          }
-   *      } );
-   */
-  fnReorderCallback: null
-};
-
-
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * Constants
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-/**
- * ColReorder version
- *  @constant  version
- *  @type      String
- *  @default   As code
- */
-ColReorder.version = "1.1.3-dev";
-
-
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * DataTables interfaces
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-// Expose
-$.fn.dataTable.ColReorder = ColReorder;
-$.fn.DataTable.ColReorder = ColReorder;
-
-
-// Register a new feature with DataTables
-if ( typeof $.fn.dataTable == "function" &&
-     typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
-     $.fn.dataTableExt.fnVersionCheck('1.9.3') )
-{
-  $.fn.dataTableExt.aoFeatures.push( {
-    "fnInit": function( settings ) {
-      var table = settings.oInstance;
-
-      if ( ! settings._colReorder ) {
-        var dtInit = settings.oInit;
-        var opts = dtInit.colReorder || dtInit.oColReorder || {};
-
-        new ColReorder( settings, opts );
-      }
-      else {
-        table.oApi._fnLog( settings, 1, "ColReorder attempted to initialise twice. Ignoring second" );
-      }
-
-      return null; /* No node for DataTables to insert */
+      this.dom.pointer = $('<div></div>')
+        .addClass( 'DTCR_pointer' )
+        .css( {
+          position: 'absolute',
+          top: scrolling ?
+            $('div.dataTables_scroll', this.s.dt.nTableWrapper).offset().top :
+            $(this.s.dt.nTable).offset().top,
+          height : scrolling ?
+            $('div.dataTables_scroll', this.s.dt.nTableWrapper).height() :
+            $(this.s.dt.nTable).height()
+        } )
+        .appendTo( 'body' );
     },
-    "cFeature": "R",
-    "sFeature": "ColReorder"
-  } );
-}
-else {
-  alert( "Warning: ColReorder requires DataTables 1.9.3 or greater - www.datatables.net/download");
-}
+
+    /**
+     * Clean up ColReorder memory references and event handlers
+     *  @method  _fnDestroy
+     *  @returns void
+     *  @private
+     */
+    "_fnDestroy": function ()
+    {
+      var i, iLen;
+
+      for ( i=0, iLen=this.s.dt.aoDrawCallback.length ; i<iLen ; i++ )
+      {
+        if ( this.s.dt.aoDrawCallback[i].sName === 'ColReorder_Pre' )
+        {
+          this.s.dt.aoDrawCallback.splice( i, 1 );
+          break;
+        }
+      }
+
+      $(this.s.dt.nTHead).find( '*' ).off( '.ColReorder' );
+
+      $.each( this.s.dt.aoColumns, function (i, column) {
+        $(column.nTh).removeAttr('data-column-index');
+      } );
+
+      this.s.dt._colReorder = null;
+      this.s = null;
+    },
 
 
-// API augmentation
-if ( $.fn.dataTable.Api ) {
-  $.fn.dataTable.Api.register( 'colReorder.reset()', function () {
-    return this.iterator( 'table', function ( ctx ) {
-      ctx._colReorder.fnReset();
-    } );
-  } );
-
-  $.fn.dataTable.Api.register( 'colReorder.order()', function ( set ) {
-    if ( set ) {
-      return this.iterator( 'table', function ( ctx ) {
-        ctx._colReorder.fnOrder( set );
+    /**
+     * Add a data attribute to the column headers, so we know the index of
+     * the row to be reordered. This allows fast detection of the index, and
+     * for this plug-in to work with FixedHeader which clones the nodes.
+     *  @private
+     */
+    "_fnSetColumnIndexes": function ()
+    {
+      $.each( this.s.dt.aoColumns, function (i, column) {
+        $(column.nTh).attr('data-column-index', i);
       } );
     }
-
-    return this.context.length ?
-      this.context[0]._colReorder.fnOrder() :
-      null;
-  } );
-}
-
-return ColReorder;
-}; // /factory
+  };
 
 
-// Define as an AMD module if possible
-if ( typeof define === 'function' && define.amd ) {
-  define( ['jquery', 'datatables'], factory );
-}
-else if ( typeof exports === 'object' ) {
-    // Node/CommonJS
-    factory( require('jquery'), require('datatables') );
-}
-else if ( jQuery && !jQuery.fn.dataTable.ColReorder ) {
-  // Otherwise simply initialise as normal, stopping multiple evaluation
-  factory( jQuery, jQuery.fn.dataTable );
-}
+
+
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * Static parameters
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+
+  /**
+   * ColReorder default settings for initialisation
+   *  @namespace
+   *  @static
+   */
+  ColReorder.defaults = {
+    /**
+     * Predefined ordering for the columns that will be applied automatically
+     * on initialisation. If not specified then the order that the columns are
+     * found to be in the HTML is the order used.
+     *  @type array
+     *  @default null
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "aiOrder": [ 4, 3, 2, 1, 0 ]
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "aiOrder": [ 4, 3, 2, 1, 0 ]
+     *      } );
+     */
+    aiOrder: null,
+
+    /**
+     * Redraw the table's column ordering as the end user draws the column
+     * (`true`) or wait until the mouse is released (`false` - default). Note
+     * that this will perform a redraw on each reordering, which involves an
+     * Ajax request each time if you are using server-side processing in
+     * DataTables.
+     *  @type boolean
+     *  @default false
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "bRealtime": true
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "bRealtime": true
+     *      } );
+     */
+    bRealtime: false,
+
+    /**
+     * Indicate how many columns should be fixed in position (counting from the
+     * left). This will typically be 1 if used, but can be as high as you like.
+     *  @type int
+     *  @default 0
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "iFixedColumns": 1
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "iFixedColumns": 1
+     *      } );
+     */
+    iFixedColumns: 0,
+
+    /**
+     * As `iFixedColumnsRight` but counting from the right.
+     *  @type int
+     *  @default 0
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "iFixedColumnsRight": 1
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "iFixedColumnsRight": 1
+     *      } );
+     */
+    iFixedColumnsRight: 0,
+
+    /**
+     * Callback function that is fired when columns are reordered
+     *  @type function():void
+     *  @default null
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "fnReorderCallback": function () {
+     *                  alert( 'Columns reordered' );
+     *              }
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "fnReorderCallback": function () {
+     *              alert( 'Columns reordered' );
+     *          }
+     *      } );
+     */
+    fnReorderCallback: null
+  };
+
+
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * Constants
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+  /**
+   * ColReorder version
+   *  @constant  version
+   *  @type      String
+   *  @default   As code
+   */
+  ColReorder.version = "1.1.3-dev";
+
+
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * DataTables interfaces
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+  // Expose
+  $.fn.dataTable.ColReorder = ColReorder;
+  $.fn.DataTable.ColReorder = ColReorder;
+
+
+  // Register a new feature with DataTables
+  if ( typeof $.fn.dataTable == "function" &&
+       typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
+       $.fn.dataTableExt.fnVersionCheck('1.9.3') )
+  {
+    $.fn.dataTableExt.aoFeatures.push( {
+      "fnInit": function( settings ) {
+        var table = settings.oInstance;
+
+        if ( ! settings._colReorder ) {
+          var dtInit = settings.oInit;
+          var opts = dtInit.colReorder || dtInit.oColReorder || {};
+
+          new ColReorder( settings, opts );
+        }
+        else {
+          table.oApi._fnLog( settings, 1, "ColReorder attempted to initialise twice. Ignoring second" );
+        }
+
+        return null; /* No node for DataTables to insert */
+      },
+      "cFeature": "R",
+      "sFeature": "ColReorder"
+    } );
+  }
+  else {
+    alert( "Warning: ColReorder requires DataTables 1.9.3 or greater - www.datatables.net/download");
+  }
+
+
+  // API augmentation
+  if ( $.fn.dataTable.Api ) {
+    $.fn.dataTable.Api.register( 'colReorder.reset()', function () {
+      return this.iterator( 'table', function ( ctx ) {
+        ctx._colReorder.fnReset();
+      } );
+    } );
+
+    $.fn.dataTable.Api.register( 'colReorder.order()', function ( set ) {
+      if ( set ) {
+        return this.iterator( 'table', function ( ctx ) {
+          ctx._colReorder.fnOrder( set );
+        } );
+      }
+
+      return this.context.length ?
+        this.context[0]._colReorder.fnOrder() :
+        null;
+    } );
+  }
+
+  return ColReorder;
+  }; // /factory
+
+
+  // Define as an AMD module if possible
+  if ( typeof define === 'function' && define.amd ) {
+    define( ['jquery', 'datatables'], factory );
+  }
+  else if ( typeof exports === 'object' ) {
+      // Node/CommonJS
+      factory( require('jquery'), require('datatables') );
+  }
+  else if ( jQuery && !jQuery.fn.dataTable.ColReorder ) {
+    // Otherwise simply initialise as normal, stopping multiple evaluation
+    factory( jQuery, jQuery.fn.dataTable );
+  }
 
 
 })(window, document);
+
 
     app.view.dataTable = function(name, baseClassName, properties) {
       var baseClass;

--- a/examples_server/examples/data_table/basic_with_pagination/data_table.js
+++ b/examples_server/examples/data_table/basic_with_pagination/data_table.js
@@ -52,7 +52,9 @@ Backdraft.app("TableExample", function(app) {
 
     rowClassName : "BookRow",
 
-    layout : "t<'row'<'col-xs-4'p><'col-xs-4'l><'col-xs-4'i>>"
+    layout : "t<'row'<'col-xs-4'p><'col-xs-4'l><'col-xs-4'i>>",
+
+    resizableColumns: true
 
   });
 

--- a/spec/plugins/data_table/general.js
+++ b/spec/plugins/data_table/general.js
@@ -557,13 +557,57 @@ describe("DataTable Plugin", function() {
       expect(reorderableSpy).not.toHaveBeenCalled();
     });
 
+    it("should default column resize to off", function() {
+      app.view.dataTable.row("abc", {
+        columns : [
+          { attr: "name", title: "Name" },
+          { attr: "age", title: "Age" }
+        ]
+      });
+
+      app.view.dataTable("def", {
+        rowClassName : "abc"
+      });
+
+      var table = new app.Views.def({ collection : collection }).render();
+
+      expect(table.resizableColumns).toEqual(false, "Table resizableColumns default");
+      expect(table._colReorder.s.allowResize).toEqual(false, "ColReorder allowResize");
+      expect(table._colReorder.s.allowReorder).toEqual(true, "ColReorder allowReorder");
+    });
+
+    it("should allow columns to be resized with flag", function() {
+      app.view.dataTable.row("abc", {
+        columns : [
+          { attr: "name", title: "Name" },
+          { attr: "age", title: "Age" }
+        ]
+      });
+
+      app.view.dataTable("def", {
+        rowClassName : "abc",
+        resizableColumns : true
+      });
+
+      var table = new app.Views.def({ collection : collection }).render();
+
+      expect(table.resizableColumns).toEqual(true, "Table resizableColumns default");
+      expect(table._colReorder.s.allowResize).toEqual(true, "ColReorder allowResize");
+      expect(table._colReorder.s.allowReorder).toEqual(true, "ColReorder allowReorder");
+
+      // these should set to off as they cause display issues
+      expect(table._colReorder.s.bAddFixed).toEqual(false, "ColReorder bAddFixed");
+      expect(table._colReorder.s.bResizeTableWrapper).toEqual(false, "ColReorder bResizeTableWrapper");
+      expect(table._colReorder.s.allowHeaderDoubleClick).toEqual(false, "ColReorder allowHeaderDoubleClick");
+    });
+
     it("should keep track of columns being reordered", function() {
       app.view.dataTable.row("abc", {
         columns : [
           { attr: "name", title: "Name" },
           { attr: "age", title: "Age" },
           { attr: "location", title: "Location" },
-          { attr: "bday", title: "Birthday" },
+          { attr: "bday", title: "Birthday" }
         ]
       });
       app.view.dataTable("def", {
@@ -576,8 +620,8 @@ describe("DataTable Plugin", function() {
       expect(_.pluck(table.columnsConfig(), "title")).toEqual(["Name", "Age", "Location", "Birthday"]);
       // move the Birthday column at index 3 to in front of Name column at index 0
       // note that we need to manually trigger the drag drop callback since we aren't actually dragging in the test
-      table.dataTable.fnSettings()._colReorder.fnOrder([3, 0, 1, 2]);
-      table.dataTable.fnSettings()._colReorder.s.dropCallback(3, 0);
+      table._colReorder.fnOrder([3, 0, 1, 2]);
+      table._colReorder.s.dropCallback(3, 0);
       expect(_.pluck(table.columnsConfig(), "title")).toEqual(["Birthday", "Name", "Age", "Location"]);
 
       // ensure that our internal title to index mappings are up to date
@@ -616,10 +660,10 @@ describe("DataTable Plugin", function() {
       });
 
       it("should restore column order", function() {
-        table.dataTable.fnSettings()._colReorder.fnOrder([3, 0, 1, 2]);
-        table.dataTable.fnSettings()._colReorder.s.dropCallback(3, 0);
-        table.dataTable.fnSettings()._colReorder.fnOrder([0, 1, 3, 2]);
-        table.dataTable.fnSettings()._colReorder.s.dropCallback(3, 2);
+        table._colReorder.fnOrder([3, 0, 1, 2]);
+        table._colReorder.s.dropCallback(3, 0);
+        table._colReorder.fnOrder([0, 1, 3, 2]);
+        table._colReorder.s.dropCallback(3, 2);
         expect(_.pluck(table.columnsConfig(), "title")).toEqual(['Attr4', 'Attr1', 'Attr3', 'Attr2']);
         expect(table._columnManager._configGenerator.columnIndexByTitle.get('Attr1')).toEqual(1);
 

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -1,8 +1,9 @@
 /*
  * File:        ColReorderWithResize-1.1.0-dev2.js
  *
+ * Based on (with minor changes):
  * https://github.com/jhubble/ColReorderWithResize/blob/0aebd15b89debe9d52efe5c6b29c07703c025e3d/media/js/ColReorderWithResize.js
- * 
+ *
  * Version:     1.1.0-dev2 (based on commit 2a6de4e884 done on Feb 22, 2013)
  * CVS:         $Id$
  * Description: Allow columns to be reordered in a DataTable
@@ -257,18 +258,7 @@
    * @param {object} opts ColReorder options
    */
   var ColReorder = function (dt, opts) {
-    $(dt.nTableWrapper).width($(dt.nTable).width());
-    // make sure the headers are the same width as the rest of table
-    dt.aoDrawCallback.push({
-      "fn": function ( oSettings ) {
-        $(oSettings.nTableWrapper).width($(oSettings.nTable).width());
-      },
-      "sName": "Resize headers"
-    });
     var oDTSettings;
-    // Set the table to minimum size so that it doesn't stretch too far
-    $(dt.nTable).width("10px");
-
 
     // @todo - This should really be a static method offered by DataTables
     if (dt.fnSettings) {
@@ -429,11 +419,18 @@
       /**
        * Resize the table when columns are resized
        * @property bResizeTable
-       * @type     bolean
+       * @type     boolean
        * @default  true
        */
       "bResizeTable": true,
 
+      /**
+       * Resize the table when columns are resized
+       * @property bResizeTable
+       * @type     boolean
+       * @default  false
+       */
+      "bResizeTableWrapper": true,
 
       /**
        * Callback called after each time the table is resized
@@ -454,7 +451,7 @@
        *  after the headers are allocated their full space. In this case, you can manually add the css
        *  in fnHeaderCallback and set bAddFixed to false here)
        * @property bAddFixed
-       * @type     bolean
+       * @type     boolean
        * @default  true
        */
       "bAddFixed": true
@@ -503,8 +500,22 @@
     ColReorder.aoInstances.push(this);
 
 
+    if (this.s.bResizeTableWrapper) {
+      $(this.s.dt.nTableWrapper).width($(this.s.dt.nTable).width());
+
+      // make sure the headers are the same width as the rest of table
+      oDTSettings.aoDrawCallback.push({
+        "fn": function ( oSettings ) {
+          $(oSettings.nTableWrapper).width($(oSettings.nTable).width());
+        },
+        "sName": "Resize headers"
+      });
+    }
+
     // fix the width and add table layout fixed.
     if (this.s.bAddFixed) {
+      // Set the table to minimum size so that it doesn't stretch too far
+      $(this.s.dt.nTable).width("10px");
       $(this.s.dt.nTable).width($(this.s.dt.nTable).width()).css('table-layout','fixed');
     }
     return this;
@@ -699,6 +710,10 @@
 
       if (typeof this.s.init.bResizeTable != 'undefined') {
         this.s.bResizeTable = this.s.init.bResizeTable;
+      }
+
+      if (typeof this.s.init.bResizeTableWrapper != 'undefined') {
+        this.s.bResizeTableWrapper = this.s.init.bResizeTableWrapper;
       }
 
       if (typeof this.s.init.bAddFixed != 'undefined') {
@@ -1376,7 +1391,9 @@
           }
         }
 
-        $(this.s.dt.nTableWrapper).width($(this.s.dt.nTable).width());
+        if (this.s.bResizeTableWrapper) {
+          $(this.s.dt.nTableWrapper).width($(this.s.dt.nTable).width());
+        }
 
         //Save the state
         this.s.dt.oInstance.oApi._fnSaveState(this.s.dt);

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -24,938 +24,710 @@
 (function(window, document, undefined) {
 
 
-/**
- * Switch the key value pairing of an index array to be value key (i.e. the old value is now the
- * key). For example consider [ 2, 0, 1 ] this would be returned as [ 1, 2, 0 ].
- *  @method  fnInvertKeyValues
- *  @param   array aIn Array to switch around
- *  @returns array
- */
-function fnInvertKeyValues( aIn )
-{
-  var aRet=[];
-  for ( var i=0, iLen=aIn.length ; i<iLen ; i++ )
+  /**
+   * Switch the key value pairing of an index array to be value key (i.e. the old value is now the
+   * key). For example consider [ 2, 0, 1 ] this would be returned as [ 1, 2, 0 ].
+   *  @method  fnInvertKeyValues
+   *  @param   array aIn Array to switch around
+   *  @returns array
+   */
+  function fnInvertKeyValues( aIn )
   {
-    aRet[ aIn[i] ] = i;
-  }
-  return aRet;
-}
-
-
-/**
- * Modify an array by switching the position of two elements
- *  @method  fnArraySwitch
- *  @param   array aArray Array to consider, will be modified by reference (i.e. no return)
- *  @param   int iFrom From point
- *  @param   int iTo Insert point
- *  @returns void
- */
-function fnArraySwitch( aArray, iFrom, iTo )
-{
-  var mStore = aArray.splice( iFrom, 1 )[0];
-  aArray.splice( iTo, 0, mStore );
-}
-
-
-/**
- * Switch the positions of nodes in a parent node (note this is specifically designed for
- * table rows). Note this function considers all element nodes under the parent!
- *  @method  fnDomSwitch
- *  @param   string sTag Tag to consider
- *  @param   int iFrom Element to move
- *  @param   int Point to element the element to (before this point), can be null for append
- *  @returns void
- */
-function fnDomSwitch( nParent, iFrom, iTo )
-{
-  var anTags = [];
-  for ( var i=0, iLen=nParent.childNodes.length ; i<iLen ; i++ )
-  {
-    if ( nParent.childNodes[i].nodeType == 1 )
+    var aRet=[];
+    for ( var i=0, iLen=aIn.length ; i<iLen ; i++ )
     {
-      anTags.push( nParent.childNodes[i] );
+      aRet[ aIn[i] ] = i;
+    }
+    return aRet;
+  }
+
+
+  /**
+   * Modify an array by switching the position of two elements
+   *  @method  fnArraySwitch
+   *  @param   array aArray Array to consider, will be modified by reference (i.e. no return)
+   *  @param   int iFrom From point
+   *  @param   int iTo Insert point
+   *  @returns void
+   */
+  function fnArraySwitch( aArray, iFrom, iTo )
+  {
+    var mStore = aArray.splice( iFrom, 1 )[0];
+    aArray.splice( iTo, 0, mStore );
+  }
+
+
+  /**
+   * Switch the positions of nodes in a parent node (note this is specifically designed for
+   * table rows). Note this function considers all element nodes under the parent!
+   *  @method  fnDomSwitch
+   *  @param   string sTag Tag to consider
+   *  @param   int iFrom Element to move
+   *  @param   int Point to element the element to (before this point), can be null for append
+   *  @returns void
+   */
+  function fnDomSwitch( nParent, iFrom, iTo )
+  {
+    var anTags = [];
+    for ( var i=0, iLen=nParent.childNodes.length ; i<iLen ; i++ )
+    {
+      if ( nParent.childNodes[i].nodeType == 1 )
+      {
+        anTags.push( nParent.childNodes[i] );
+      }
+    }
+    var nStore = anTags[ iFrom ];
+
+    if ( iTo !== null )
+    {
+      nParent.insertBefore( nStore, anTags[iTo] );
+    }
+    else
+    {
+      nParent.appendChild( nStore );
     }
   }
-  var nStore = anTags[ iFrom ];
 
-  if ( iTo !== null )
+
+
+  var factory = function( $, DataTable ) {
+  "use strict";
+
+  /**
+   * Plug-in for DataTables which will reorder the internal column structure by taking the column
+   * from one position (iFrom) and insert it into a given point (iTo).
+   *  @method  $.fn.dataTableExt.oApi.fnColReorder
+   *  @param   object oSettings DataTables settings object - automatically added by DataTables!
+   *  @param   int iFrom Take the column to be repositioned from this point
+   *  @param   int iTo and insert it into this point
+   *  @returns void
+   */
+  $.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo )
   {
-    nParent.insertBefore( nStore, anTags[iTo] );
-  }
-  else
-  {
-    nParent.appendChild( nStore );
-  }
-}
+    var v110 = $.fn.dataTable.Api ? true : false;
+    var i, iLen, j, jLen, iCols=oSettings.aoColumns.length, nTrs, oCol;
+    var attrMap = function ( obj, prop, mapping ) {
+      if ( ! obj[ prop ] ) {
+        return;
+      }
 
+      var a = obj[ prop ].split('.');
+      var num = a.shift();
 
+      if ( isNaN( num*1 ) ) {
+        return;
+      }
 
-var factory = function( $, DataTable ) {
-"use strict";
+      obj[ prop ] = mapping[ num*1 ]+'.'+a.join('.');
+    };
 
-/**
- * Plug-in for DataTables which will reorder the internal column structure by taking the column
- * from one position (iFrom) and insert it into a given point (iTo).
- *  @method  $.fn.dataTableExt.oApi.fnColReorder
- *  @param   object oSettings DataTables settings object - automatically added by DataTables!
- *  @param   int iFrom Take the column to be repositioned from this point
- *  @param   int iTo and insert it into this point
- *  @returns void
- */
-$.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo )
-{
-  var v110 = $.fn.dataTable.Api ? true : false;
-  var i, iLen, j, jLen, iCols=oSettings.aoColumns.length, nTrs, oCol;
-  var attrMap = function ( obj, prop, mapping ) {
-    if ( ! obj[ prop ] ) {
+    /* Sanity check in the input */
+    if ( iFrom == iTo )
+    {
+      /* Pointless reorder */
       return;
     }
 
-    var a = obj[ prop ].split('.');
-    var num = a.shift();
-
-    if ( isNaN( num*1 ) ) {
+    if ( iFrom < 0 || iFrom >= iCols )
+    {
+      this.oApi._fnLog( oSettings, 1, "ColReorder 'from' index is out of bounds: "+iFrom );
       return;
     }
 
-    obj[ prop ] = mapping[ num*1 ]+'.'+a.join('.');
-  };
-
-  /* Sanity check in the input */
-  if ( iFrom == iTo )
-  {
-    /* Pointless reorder */
-    return;
-  }
-
-  if ( iFrom < 0 || iFrom >= iCols )
-  {
-    this.oApi._fnLog( oSettings, 1, "ColReorder 'from' index is out of bounds: "+iFrom );
-    return;
-  }
-
-  if ( iTo < 0 || iTo >= iCols )
-  {
-    this.oApi._fnLog( oSettings, 1, "ColReorder 'to' index is out of bounds: "+iTo );
-    return;
-  }
-
-  /*
-   * Calculate the new column array index, so we have a mapping between the old and new
-   */
-  var aiMapping = [];
-  for ( i=0, iLen=iCols ; i<iLen ; i++ )
-  {
-    aiMapping[i] = i;
-  }
-  fnArraySwitch( aiMapping, iFrom, iTo );
-  var aiInvertMapping = fnInvertKeyValues( aiMapping );
-
-
-  /*
-   * Convert all internal indexing to the new column order indexes
-   */
-  /* Sorting */
-  for ( i=0, iLen=oSettings.aaSorting.length ; i<iLen ; i++ )
-  {
-    oSettings.aaSorting[i][0] = aiInvertMapping[ oSettings.aaSorting[i][0] ];
-  }
-
-  /* Fixed sorting */
-  if ( oSettings.aaSortingFixed !== null )
-  {
-    for ( i=0, iLen=oSettings.aaSortingFixed.length ; i<iLen ; i++ )
+    if ( iTo < 0 || iTo >= iCols )
     {
-      oSettings.aaSortingFixed[i][0] = aiInvertMapping[ oSettings.aaSortingFixed[i][0] ];
-    }
-  }
-
-  /* Data column sorting (the column which the sort for a given column should take place on) */
-  for ( i=0, iLen=iCols ; i<iLen ; i++ )
-  {
-    oCol = oSettings.aoColumns[i];
-    for ( j=0, jLen=oCol.aDataSort.length ; j<jLen ; j++ )
-    {
-      oCol.aDataSort[j] = aiInvertMapping[ oCol.aDataSort[j] ];
+      this.oApi._fnLog( oSettings, 1, "ColReorder 'to' index is out of bounds: "+iTo );
+      return;
     }
 
-    // Update the column indexes
-    if ( v110 ) {
-      oCol.idx = aiInvertMapping[ oCol.idx ];
-    }
-  }
-
-  if ( v110 ) {
-    // Update 1.10 optimised sort class removal variable
-    $.each( oSettings.aLastSort, function (i, val) {
-      oSettings.aLastSort[i].src = aiInvertMapping[ val.src ];
-    } );
-  }
-
-  /* Update the Get and Set functions for each column */
-  for ( i=0, iLen=iCols ; i<iLen ; i++ )
-  {
-    oCol = oSettings.aoColumns[i];
-
-    if ( typeof oCol.mData == 'number' ) {
-      oCol.mData = aiInvertMapping[ oCol.mData ];
-
-      // regenerate the get / set functions
-      oSettings.oApi._fnColumnOptions( oSettings, i, {} );
-    }
-    else if ( $.isPlainObject( oCol.mData ) ) {
-      // HTML5 data sourced
-      attrMap( oCol.mData, '_',      aiInvertMapping );
-      attrMap( oCol.mData, 'filter', aiInvertMapping );
-      attrMap( oCol.mData, 'sort',   aiInvertMapping );
-      attrMap( oCol.mData, 'type',   aiInvertMapping );
-
-      // regenerate the get / set functions
-      oSettings.oApi._fnColumnOptions( oSettings, i, {} );
-    }
-  }
-
-
-  /*
-   * Move the DOM elements
-   */
-  if ( oSettings.aoColumns[iFrom].bVisible )
-  {
-    /* Calculate the current visible index and the point to insert the node before. The insert
-     * before needs to take into account that there might not be an element to insert before,
-     * in which case it will be null, and an appendChild should be used
+    /*
+     * Calculate the new column array index, so we have a mapping between the old and new
      */
-    var iVisibleIndex = this.oApi._fnColumnIndexToVisible( oSettings, iFrom );
-    var iInsertBeforeIndex = null;
-
-    i = iTo < iFrom ? iTo : iTo + 1;
-    while ( iInsertBeforeIndex === null && i < iCols )
+    var aiMapping = [];
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
     {
-      iInsertBeforeIndex = this.oApi._fnColumnIndexToVisible( oSettings, i );
-      i++;
+      aiMapping[i] = i;
+    }
+    fnArraySwitch( aiMapping, iFrom, iTo );
+    var aiInvertMapping = fnInvertKeyValues( aiMapping );
+
+
+    /*
+     * Convert all internal indexing to the new column order indexes
+     */
+    /* Sorting */
+    for ( i=0, iLen=oSettings.aaSorting.length ; i<iLen ; i++ )
+    {
+      oSettings.aaSorting[i][0] = aiInvertMapping[ oSettings.aaSorting[i][0] ];
     }
 
-    /* Header */
-    nTrs = oSettings.nTHead.getElementsByTagName('tr');
-    for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+    /* Fixed sorting */
+    if ( oSettings.aaSortingFixed !== null )
     {
-      fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+      for ( i=0, iLen=oSettings.aaSortingFixed.length ; i<iLen ; i++ )
+      {
+        oSettings.aaSortingFixed[i][0] = aiInvertMapping[ oSettings.aaSortingFixed[i][0] ];
+      }
     }
 
-    /* Footer */
-    if ( oSettings.nTFoot !== null )
+    /* Data column sorting (the column which the sort for a given column should take place on) */
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
     {
-      nTrs = oSettings.nTFoot.getElementsByTagName('tr');
+      oCol = oSettings.aoColumns[i];
+      for ( j=0, jLen=oCol.aDataSort.length ; j<jLen ; j++ )
+      {
+        oCol.aDataSort[j] = aiInvertMapping[ oCol.aDataSort[j] ];
+      }
+
+      // Update the column indexes
+      if ( v110 ) {
+        oCol.idx = aiInvertMapping[ oCol.idx ];
+      }
+    }
+
+    if ( v110 ) {
+      // Update 1.10 optimised sort class removal variable
+      $.each( oSettings.aLastSort, function (i, val) {
+        oSettings.aLastSort[i].src = aiInvertMapping[ val.src ];
+      } );
+    }
+
+    /* Update the Get and Set functions for each column */
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
+    {
+      oCol = oSettings.aoColumns[i];
+
+      if ( typeof oCol.mData == 'number' ) {
+        oCol.mData = aiInvertMapping[ oCol.mData ];
+
+        // regenerate the get / set functions
+        oSettings.oApi._fnColumnOptions( oSettings, i, {} );
+      }
+      else if ( $.isPlainObject( oCol.mData ) ) {
+        // HTML5 data sourced
+        attrMap( oCol.mData, '_',      aiInvertMapping );
+        attrMap( oCol.mData, 'filter', aiInvertMapping );
+        attrMap( oCol.mData, 'sort',   aiInvertMapping );
+        attrMap( oCol.mData, 'type',   aiInvertMapping );
+
+        // regenerate the get / set functions
+        oSettings.oApi._fnColumnOptions( oSettings, i, {} );
+      }
+    }
+
+
+    /*
+     * Move the DOM elements
+     */
+    if ( oSettings.aoColumns[iFrom].bVisible )
+    {
+      /* Calculate the current visible index and the point to insert the node before. The insert
+       * before needs to take into account that there might not be an element to insert before,
+       * in which case it will be null, and an appendChild should be used
+       */
+      var iVisibleIndex = this.oApi._fnColumnIndexToVisible( oSettings, iFrom );
+      var iInsertBeforeIndex = null;
+
+      i = iTo < iFrom ? iTo : iTo + 1;
+      while ( iInsertBeforeIndex === null && i < iCols )
+      {
+        iInsertBeforeIndex = this.oApi._fnColumnIndexToVisible( oSettings, i );
+        i++;
+      }
+
+      /* Header */
+      nTrs = oSettings.nTHead.getElementsByTagName('tr');
       for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
       {
         fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
       }
+
+      /* Footer */
+      if ( oSettings.nTFoot !== null )
+      {
+        nTrs = oSettings.nTFoot.getElementsByTagName('tr');
+        for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+        {
+          fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+        }
+      }
+
+      /* Body */
+      for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
+      {
+        if ( oSettings.aoData[i].nTr !== null )
+        {
+          fnDomSwitch( oSettings.aoData[i].nTr, iVisibleIndex, iInsertBeforeIndex );
+        }
+      }
     }
 
-    /* Body */
+    /*
+     * Move the internal array elements
+     */
+    /* Columns */
+    fnArraySwitch( oSettings.aoColumns, iFrom, iTo );
+
+    /* Search columns */
+    fnArraySwitch( oSettings.aoPreSearchCols, iFrom, iTo );
+
+    /* Array array - internal data anodes cache */
     for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
     {
-      if ( oSettings.aoData[i].nTr !== null )
-      {
-        fnDomSwitch( oSettings.aoData[i].nTr, iVisibleIndex, iInsertBeforeIndex );
+      var data = oSettings.aoData[i];
+
+      if ( v110 ) {
+        // DataTables 1.10+
+        if ( data.anCells ) {
+          fnArraySwitch( data.anCells, iFrom, iTo );
+        }
+
+        // For DOM sourced data, the invalidate will reread the cell into
+        // the data array, but for data sources as an array, they need to
+        // be flipped
+        if ( data.src !== 'dom' && $.isArray( data._aData ) ) {
+          fnArraySwitch( data._aData, iFrom, iTo );
+        }
+      }
+      else {
+        // DataTables 1.9-
+        if ( $.isArray( data._aData ) ) {
+          fnArraySwitch( data._aData, iFrom, iTo );
+        }
+        fnArraySwitch( data._anHidden, iFrom, iTo );
       }
     }
-  }
 
-  /*
-   * Move the internal array elements
-   */
-  /* Columns */
-  fnArraySwitch( oSettings.aoColumns, iFrom, iTo );
+    /* Reposition the header elements in the header layout array */
+    for ( i=0, iLen=oSettings.aoHeader.length ; i<iLen ; i++ )
+    {
+      fnArraySwitch( oSettings.aoHeader[i], iFrom, iTo );
+    }
 
-  /* Search columns */
-  fnArraySwitch( oSettings.aoPreSearchCols, iFrom, iTo );
-
-  /* Array array - internal data anodes cache */
-  for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
-  {
-    var data = oSettings.aoData[i];
-
-    if ( v110 ) {
-      // DataTables 1.10+
-      if ( data.anCells ) {
-        fnArraySwitch( data.anCells, iFrom, iTo );
+    if ( oSettings.aoFooter !== null )
+    {
+      for ( i=0, iLen=oSettings.aoFooter.length ; i<iLen ; i++ )
+      {
+        fnArraySwitch( oSettings.aoFooter[i], iFrom, iTo );
       }
+    }
 
-      // For DOM sourced data, the invalidate will reread the cell into
-      // the data array, but for data sources as an array, they need to
-      // be flipped
-      if ( data.src !== 'dom' && $.isArray( data._aData ) ) {
-        fnArraySwitch( data._aData, iFrom, iTo );
+    // In 1.10 we need to invalidate row cached data for sorting, filtering etc
+    if ( v110 ) {
+      var api = new $.fn.dataTable.Api( oSettings );
+      api.rows().invalidate();
+    }
+
+    /*
+     * Update DataTables' event handlers
+     */
+
+    /* Sort listener */
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
+    {
+      $(oSettings.aoColumns[i].nTh).off('click.DT');
+      this.oApi._fnSortAttachListener( oSettings, oSettings.aoColumns[i].nTh, i );
+    }
+
+
+    /* Fire an event so other plug-ins can update */
+    $(oSettings.oInstance).trigger( 'column-reorder', [ oSettings, {
+      "iFrom": iFrom,
+      "iTo": iTo,
+      "aiInvertMapping": aiInvertMapping
+    } ] );
+  };
+
+
+  /**
+   * ColReorder provides column visibility control for DataTables
+   * @class ColReorder
+   * @constructor
+   * @param {object} dt DataTables settings object
+   * @param {object} opts ColReorder options
+   */
+  var ColReorder = function( dt, opts )
+  {
+    var oDTSettings;
+
+    if ( $.fn.dataTable.Api ) {
+      oDTSettings = new $.fn.dataTable.Api( dt ).settings()[0];
+    }
+    // 1.9 compatibility
+    else if ( dt.fnSettings ) {
+      // DataTables object, convert to the settings object
+      oDTSettings = dt.fnSettings();
+    }
+    else if ( typeof dt === 'string' ) {
+      // jQuery selector
+      if ( $.fn.dataTable.fnIsDataTable( $(dt)[0] ) ) {
+        oDTSettings = $(dt).eq(0).dataTable().fnSettings();
+      }
+    }
+    else if ( dt.nodeName && dt.nodeName.toLowerCase() === 'table' ) {
+      // Table node
+      if ( $.fn.dataTable.fnIsDataTable( dt.nodeName ) ) {
+        oDTSettings = $(dt.nodeName).dataTable().fnSettings();
+      }
+    }
+    else if ( dt instanceof jQuery ) {
+      // jQuery object
+      if ( $.fn.dataTable.fnIsDataTable( dt[0] ) ) {
+        oDTSettings = dt.eq(0).dataTable().fnSettings();
       }
     }
     else {
-      // DataTables 1.9-
-      if ( $.isArray( data._aData ) ) {
-        fnArraySwitch( data._aData, iFrom, iTo );
-      }
-      fnArraySwitch( data._anHidden, iFrom, iTo );
-    }
-  }
-
-  /* Reposition the header elements in the header layout array */
-  for ( i=0, iLen=oSettings.aoHeader.length ; i<iLen ; i++ )
-  {
-    fnArraySwitch( oSettings.aoHeader[i], iFrom, iTo );
-  }
-
-  if ( oSettings.aoFooter !== null )
-  {
-    for ( i=0, iLen=oSettings.aoFooter.length ; i<iLen ; i++ )
-    {
-      fnArraySwitch( oSettings.aoFooter[i], iFrom, iTo );
-    }
-  }
-
-  // In 1.10 we need to invalidate row cached data for sorting, filtering etc
-  if ( v110 ) {
-    var api = new $.fn.dataTable.Api( oSettings );
-    api.rows().invalidate();
-  }
-
-  /*
-   * Update DataTables' event handlers
-   */
-
-  /* Sort listener */
-  for ( i=0, iLen=iCols ; i<iLen ; i++ )
-  {
-    $(oSettings.aoColumns[i].nTh).off('click.DT');
-    this.oApi._fnSortAttachListener( oSettings, oSettings.aoColumns[i].nTh, i );
-  }
-
-
-  /* Fire an event so other plug-ins can update */
-  $(oSettings.oInstance).trigger( 'column-reorder', [ oSettings, {
-    "iFrom": iFrom,
-    "iTo": iTo,
-    "aiInvertMapping": aiInvertMapping
-  } ] );
-};
-
-
-/**
- * ColReorder provides column visibility control for DataTables
- * @class ColReorder
- * @constructor
- * @param {object} dt DataTables settings object
- * @param {object} opts ColReorder options
- */
-var ColReorder = function( dt, opts )
-{
-  var oDTSettings;
-
-  if ( $.fn.dataTable.Api ) {
-    oDTSettings = new $.fn.dataTable.Api( dt ).settings()[0];
-  }
-  // 1.9 compatibility
-  else if ( dt.fnSettings ) {
-    // DataTables object, convert to the settings object
-    oDTSettings = dt.fnSettings();
-  }
-  else if ( typeof dt === 'string' ) {
-    // jQuery selector
-    if ( $.fn.dataTable.fnIsDataTable( $(dt)[0] ) ) {
-      oDTSettings = $(dt).eq(0).dataTable().fnSettings();
-    }
-  }
-  else if ( dt.nodeName && dt.nodeName.toLowerCase() === 'table' ) {
-    // Table node
-    if ( $.fn.dataTable.fnIsDataTable( dt.nodeName ) ) {
-      oDTSettings = $(dt.nodeName).dataTable().fnSettings();
-    }
-  }
-  else if ( dt instanceof jQuery ) {
-    // jQuery object
-    if ( $.fn.dataTable.fnIsDataTable( dt[0] ) ) {
-      oDTSettings = dt.eq(0).dataTable().fnSettings();
-    }
-  }
-  else {
-    // DataTables settings object
-    oDTSettings = dt;
-  }
-
-  // Ensure that we can't initialise on the same table twice
-  if ( oDTSettings._colReorder ) {
-    throw "ColReorder already initialised on table #"+oDTSettings.nTable.id;
-  }
-
-  // Convert from camelCase to Hungarian, just as DataTables does
-  var camelToHungarian = $.fn.dataTable.camelToHungarian;
-  if ( camelToHungarian ) {
-    camelToHungarian( ColReorder.defaults, ColReorder.defaults, true );
-    camelToHungarian( ColReorder.defaults, opts || {} );
-  }
-
-
-  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * Public class variables
-   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-  /**
-   * @namespace Settings object which contains customisable information for ColReorder instance
-   */
-  this.s = {
-    /**
-     * DataTables settings object
-     *  @property dt
-     *  @type     Object
-     *  @default  null
-     */
-    "dt": null,
-
-    /**
-     * Initialisation object used for this instance
-     *  @property init
-     *  @type     object
-     *  @default  {}
-     */
-    "init": $.extend( true, {}, ColReorder.defaults, opts ),
-
-    /**
-     * Number of columns to fix (not allow to be reordered)
-     *  @property fixed
-     *  @type     int
-     *  @default  0
-     */
-    "fixed": 0,
-
-    /**
-     * Number of columns to fix counting from right (not allow to be reordered)
-     *  @property fixedRight
-     *  @type     int
-     *  @default  0
-     */
-    "fixedRight": 0,
-
-    /**
-     * Callback function for once the reorder has been done
-     *  @property dropcallback
-     *  @type     function
-     *  @default  null
-     */
-    "dropCallback": null,
-
-    /**
-     * @namespace Information used for the mouse drag
-     */
-    "mouse": {
-      "startX": -1,
-      "startY": -1,
-      "offsetX": -1,
-      "offsetY": -1,
-      "target": -1,
-      "targetIndex": -1,
-      "fromIndex": -1
-    },
-
-    /**
-     * Information which is used for positioning the insert cusor and knowing where to do the
-     * insert. Array of objects with the properties:
-     *   x: x-axis position
-     *   to: insert point
-     *  @property aoTargets
-     *  @type     array
-     *  @default  []
-     */
-    "aoTargets": []
-  };
-
-
-  /**
-   * @namespace Common and useful DOM elements for the class instance
-   */
-  this.dom = {
-    /**
-     * Dragging element (the one the mouse is moving)
-     *  @property drag
-     *  @type     element
-     *  @default  null
-     */
-    "drag": null,
-
-    /**
-     * The insert cursor
-     *  @property pointer
-     *  @type     element
-     *  @default  null
-     */
-    "pointer": null
-  };
-
-
-  /* Constructor logic */
-  this.s.dt = oDTSettings;
-  this.s.dt._colReorder = this;
-  this._fnConstruct();
-
-  /* Add destroy callback */
-  oDTSettings.oApi._fnCallbackReg(oDTSettings, 'aoDestroyCallback', $.proxy(this._fnDestroy, this), 'ColReorder');
-
-  return this;
-};
-
-
-
-ColReorder.prototype = {
-  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * Public methods
-   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-  /**
-   * Reset the column ordering to the original ordering that was detected on
-   * start up.
-   *  @return {this} Returns `this` for chaining.
-   *
-   *  @example
-   *    // DataTables initialisation with ColReorder
-   *    var table = $('#example').dataTable( {
-   *        "sDom": 'Rlfrtip'
-   *    } );
-   *
-   *    // Add click event to a button to reset the ordering
-   *    $('#resetOrdering').click( function (e) {
-   *        e.preventDefault();
-   *        $.fn.dataTable.ColReorder( table ).fnReset();
-   *    } );
-   */
-  "fnReset": function ()
-  {
-    var a = [];
-    for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
-    {
-      a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
+      // DataTables settings object
+      oDTSettings = dt;
     }
 
-    this._fnOrderColumns( a );
+    // Ensure that we can't initialise on the same table twice
+    if ( oDTSettings._colReorder ) {
+      throw "ColReorder already initialised on table #"+oDTSettings.nTable.id;
+    }
+
+    // Convert from camelCase to Hungarian, just as DataTables does
+    var camelToHungarian = $.fn.dataTable.camelToHungarian;
+    if ( camelToHungarian ) {
+      camelToHungarian( ColReorder.defaults, ColReorder.defaults, true );
+      camelToHungarian( ColReorder.defaults, opts || {} );
+    }
+
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Public class variables
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /**
+     * @namespace Settings object which contains customisable information for ColReorder instance
+     */
+    this.s = {
+      /**
+       * DataTables settings object
+       *  @property dt
+       *  @type     Object
+       *  @default  null
+       */
+      "dt": null,
+
+      /**
+       * Initialisation object used for this instance
+       *  @property init
+       *  @type     object
+       *  @default  {}
+       */
+      "init": $.extend( true, {}, ColReorder.defaults, opts ),
+
+      /**
+       * Number of columns to fix (not allow to be reordered)
+       *  @property fixed
+       *  @type     int
+       *  @default  0
+       */
+      "fixed": 0,
+
+      /**
+       * Number of columns to fix counting from right (not allow to be reordered)
+       *  @property fixedRight
+       *  @type     int
+       *  @default  0
+       */
+      "fixedRight": 0,
+
+      /**
+       * Callback function for once the reorder has been done
+       *  @property dropcallback
+       *  @type     function
+       *  @default  null
+       */
+      "dropCallback": null,
+
+      /**
+       * @namespace Information used for the mouse drag
+       */
+      "mouse": {
+        "startX": -1,
+        "startY": -1,
+        "offsetX": -1,
+        "offsetY": -1,
+        "target": -1,
+        "targetIndex": -1,
+        "fromIndex": -1
+      },
+
+      /**
+       * Information which is used for positioning the insert cusor and knowing where to do the
+       * insert. Array of objects with the properties:
+       *   x: x-axis position
+       *   to: insert point
+       *  @property aoTargets
+       *  @type     array
+       *  @default  []
+       */
+      "aoTargets": []
+    };
+
+
+    /**
+     * @namespace Common and useful DOM elements for the class instance
+     */
+    this.dom = {
+      /**
+       * Dragging element (the one the mouse is moving)
+       *  @property drag
+       *  @type     element
+       *  @default  null
+       */
+      "drag": null,
+
+      /**
+       * The insert cursor
+       *  @property pointer
+       *  @type     element
+       *  @default  null
+       */
+      "pointer": null
+    };
+
+
+    /* Constructor logic */
+    this.s.dt = oDTSettings;
+    this.s.dt._colReorder = this;
+    this._fnConstruct();
+
+    /* Add destroy callback */
+    oDTSettings.oApi._fnCallbackReg(oDTSettings, 'aoDestroyCallback', $.proxy(this._fnDestroy, this), 'ColReorder');
 
     return this;
-  },
+  };
 
-  /**
-   * `Deprecated` - Get the current order of the columns, as an array.
-   *  @return {array} Array of column identifiers
-   *  @deprecated `fnOrder` should be used in preference to this method.
-   *      `fnOrder` acts as a getter/setter.
-   */
-  "fnGetCurrentOrder": function ()
-  {
-    return this.fnOrder();
-  },
 
-  /**
-   * Get the current order of the columns, as an array. Note that the values
-   * given in the array are unique identifiers for each column. Currently
-   * these are the original ordering of the columns that was detected on
-   * start up, but this could potentially change in future.
-   *  @return {array} Array of column identifiers
-   *
-   *  @example
-   *    // Get column ordering for the table
-   *    var order = $.fn.dataTable.ColReorder( dataTable ).fnOrder();
-   *//**
-   * Set the order of the columns, from the positions identified in the
-   * ordering array given. Note that ColReorder takes a brute force approach
-   * to reordering, so it is possible multiple reordering events will occur
-   * before the final order is settled upon.
-   *  @param {array} [set] Array of column identifiers in the new order. Note
-   *    that every column must be included, uniquely, in this array.
-   *  @return {this} Returns `this` for chaining.
-   *
-   *  @example
-   *    // Swap the first and second columns
-   *    $.fn.dataTable.ColReorder( dataTable ).fnOrder( [1, 0, 2, 3, 4] );
-   *
-   *  @example
-   *    // Move the first column to the end for the table `#example`
-   *    var curr = $.fn.dataTable.ColReorder( '#example' ).fnOrder();
-   *    var first = curr.shift();
-   *    curr.push( first );
-   *    $.fn.dataTable.ColReorder( '#example' ).fnOrder( curr );
-   *
-   *  @example
-   *    // Reverse the table's order
-   *    $.fn.dataTable.ColReorder( '#example' ).fnOrder(
-   *      $.fn.dataTable.ColReorder( '#example' ).fnOrder().reverse()
-   *    );
-   */
-  "fnOrder": function ( set )
-  {
-    if ( set === undefined )
+
+  ColReorder.prototype = {
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Public methods
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /**
+     * Reset the column ordering to the original ordering that was detected on
+     * start up.
+     *  @return {this} Returns `this` for chaining.
+     *
+     *  @example
+     *    // DataTables initialisation with ColReorder
+     *    var table = $('#example').dataTable( {
+     *        "sDom": 'Rlfrtip'
+     *    } );
+     *
+     *    // Add click event to a button to reset the ordering
+     *    $('#resetOrdering').click( function (e) {
+     *        e.preventDefault();
+     *        $.fn.dataTable.ColReorder( table ).fnReset();
+     *    } );
+     */
+    "fnReset": function ()
     {
       var a = [];
       for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
       {
         a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
       }
-      return a;
-    }
 
-    this._fnOrderColumns( fnInvertKeyValues( set ) );
+      this._fnOrderColumns( a );
 
-    return this;
-  },
+      return this;
+    },
 
-
-  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * Private methods (they are of course public in JS, but recommended as private)
-   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-  /**
-   * Constructor logic
-   *  @method  _fnConstruct
-   *  @returns void
-   *  @private
-   */
-  "_fnConstruct": function ()
-  {
-    var that = this;
-    var iLen = this.s.dt.aoColumns.length;
-    var i;
-
-    /* Columns discounted from reordering - counting left to right */
-    if ( this.s.init.iFixedColumns )
+    /**
+     * `Deprecated` - Get the current order of the columns, as an array.
+     *  @return {array} Array of column identifiers
+     *  @deprecated `fnOrder` should be used in preference to this method.
+     *      `fnOrder` acts as a getter/setter.
+     */
+    "fnGetCurrentOrder": function ()
     {
-      this.s.fixed = this.s.init.iFixedColumns;
-    }
+      return this.fnOrder();
+    },
 
-    /* Columns discounted from reordering - counting right to left */
-    this.s.fixedRight = this.s.init.iFixedColumnsRight ?
-      this.s.init.iFixedColumnsRight :
-      0;
-
-    /* Drop callback initialisation option */
-    if ( this.s.init.fnReorderCallback )
+    /**
+     * Get the current order of the columns, as an array. Note that the values
+     * given in the array are unique identifiers for each column. Currently
+     * these are the original ordering of the columns that was detected on
+     * start up, but this could potentially change in future.
+     *  @return {array} Array of column identifiers
+     *
+     *  @example
+     *    // Get column ordering for the table
+     *    var order = $.fn.dataTable.ColReorder( dataTable ).fnOrder();
+     *//**
+     * Set the order of the columns, from the positions identified in the
+     * ordering array given. Note that ColReorder takes a brute force approach
+     * to reordering, so it is possible multiple reordering events will occur
+     * before the final order is settled upon.
+     *  @param {array} [set] Array of column identifiers in the new order. Note
+     *    that every column must be included, uniquely, in this array.
+     *  @return {this} Returns `this` for chaining.
+     *
+     *  @example
+     *    // Swap the first and second columns
+     *    $.fn.dataTable.ColReorder( dataTable ).fnOrder( [1, 0, 2, 3, 4] );
+     *
+     *  @example
+     *    // Move the first column to the end for the table `#example`
+     *    var curr = $.fn.dataTable.ColReorder( '#example' ).fnOrder();
+     *    var first = curr.shift();
+     *    curr.push( first );
+     *    $.fn.dataTable.ColReorder( '#example' ).fnOrder( curr );
+     *
+     *  @example
+     *    // Reverse the table's order
+     *    $.fn.dataTable.ColReorder( '#example' ).fnOrder(
+     *      $.fn.dataTable.ColReorder( '#example' ).fnOrder().reverse()
+     *    );
+     */
+    "fnOrder": function ( set )
     {
-      this.s.dropCallback = this.s.init.fnReorderCallback;
-    }
-
-    /* Add event handlers for the drag and drop, and also mark the original column order */
-    for ( i = 0; i < iLen; i++ )
-    {
-      if ( i > this.s.fixed-1 && i < iLen - this.s.fixedRight )
+      if ( set === undefined )
       {
-        this._fnMouseListener( i, this.s.dt.aoColumns[i].nTh );
+        var a = [];
+        for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
+        {
+          a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
+        }
+        return a;
       }
 
-      /* Mark the original column order for later reference */
-      this.s.dt.aoColumns[i]._ColReorder_iOrigCol = i;
-    }
+      this._fnOrderColumns( fnInvertKeyValues( set ) );
 
-    /* State saving */
-    this.s.dt.oApi._fnCallbackReg( this.s.dt, 'aoStateSaveParams', function (oS, oData) {
-      that._fnStateSave.call( that, oData );
-    }, "ColReorder_State" );
+      return this;
+    },
 
-    /* An initial column order has been specified */
-    var aiOrder = null;
-    if ( this.s.init.aiOrder )
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Private methods (they are of course public in JS, but recommended as private)
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /**
+     * Constructor logic
+     *  @method  _fnConstruct
+     *  @returns void
+     *  @private
+     */
+    "_fnConstruct": function ()
     {
-      aiOrder = this.s.init.aiOrder.slice();
-    }
+      var that = this;
+      var iLen = this.s.dt.aoColumns.length;
+      var i;
 
-    /* State loading, overrides the column order given */
-    if ( this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
-      this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length )
-    {
-      aiOrder = this.s.dt.oLoadedState.ColReorder;
-    }
-
-    /* If we have an order to apply - do so */
-    if ( aiOrder )
-    {
-      /* We might be called during or after the DataTables initialisation. If before, then we need
-       * to wait until the draw is done, if after, then do what we need to do right away
-       */
-      if ( !that.s.dt._bInitComplete )
+      /* Columns discounted from reordering - counting left to right */
+      if ( this.s.init.iFixedColumns )
       {
-        var bDone = false;
-        this.s.dt.aoDrawCallback.push( {
-          "fn": function () {
-            if ( !that.s.dt._bInitComplete && !bDone )
-            {
-              bDone = true;
-              var resort = fnInvertKeyValues( aiOrder );
-              that._fnOrderColumns.call( that, resort );
-            }
-          },
-          "sName": "ColReorder_Pre"
-        } );
+        this.s.fixed = this.s.init.iFixedColumns;
       }
-      else
+
+      /* Columns discounted from reordering - counting right to left */
+      this.s.fixedRight = this.s.init.iFixedColumnsRight ?
+        this.s.init.iFixedColumnsRight :
+        0;
+
+      /* Drop callback initialisation option */
+      if ( this.s.init.fnReorderCallback )
       {
-        var resort = fnInvertKeyValues( aiOrder );
-        that._fnOrderColumns.call( that, resort );
+        this.s.dropCallback = this.s.init.fnReorderCallback;
       }
-    }
-    else {
-      this._fnSetColumnIndexes();
-    }
-  },
+
+      /* Add event handlers for the drag and drop, and also mark the original column order */
+      for ( i = 0; i < iLen; i++ )
+      {
+        if ( i > this.s.fixed-1 && i < iLen - this.s.fixedRight )
+        {
+          this._fnMouseListener( i, this.s.dt.aoColumns[i].nTh );
+        }
+
+        /* Mark the original column order for later reference */
+        this.s.dt.aoColumns[i]._ColReorder_iOrigCol = i;
+      }
+
+      /* State saving */
+      this.s.dt.oApi._fnCallbackReg( this.s.dt, 'aoStateSaveParams', function (oS, oData) {
+        that._fnStateSave.call( that, oData );
+      }, "ColReorder_State" );
+
+      /* An initial column order has been specified */
+      var aiOrder = null;
+      if ( this.s.init.aiOrder )
+      {
+        aiOrder = this.s.init.aiOrder.slice();
+      }
+
+      /* State loading, overrides the column order given */
+      if ( this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
+        this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length )
+      {
+        aiOrder = this.s.dt.oLoadedState.ColReorder;
+      }
+
+      /* If we have an order to apply - do so */
+      if ( aiOrder )
+      {
+        /* We might be called during or after the DataTables initialisation. If before, then we need
+         * to wait until the draw is done, if after, then do what we need to do right away
+         */
+        if ( !that.s.dt._bInitComplete )
+        {
+          var bDone = false;
+          this.s.dt.aoDrawCallback.push( {
+            "fn": function () {
+              if ( !that.s.dt._bInitComplete && !bDone )
+              {
+                bDone = true;
+                var resort = fnInvertKeyValues( aiOrder );
+                that._fnOrderColumns.call( that, resort );
+              }
+            },
+            "sName": "ColReorder_Pre"
+          } );
+        }
+        else
+        {
+          var resort = fnInvertKeyValues( aiOrder );
+          that._fnOrderColumns.call( that, resort );
+        }
+      }
+      else {
+        this._fnSetColumnIndexes();
+      }
+    },
 
 
-  /**
-   * Set the column order from an array
-   *  @method  _fnOrderColumns
-   *  @param   array a An array of integers which dictate the column order that should be applied
-   *  @returns void
-   *  @private
-   */
-  "_fnOrderColumns": function ( a )
-  {
-    if ( a.length != this.s.dt.aoColumns.length )
+    /**
+     * Set the column order from an array
+     *  @method  _fnOrderColumns
+     *  @param   array a An array of integers which dictate the column order that should be applied
+     *  @returns void
+     *  @private
+     */
+    "_fnOrderColumns": function ( a )
     {
-      this.s.dt.oInstance.oApi._fnLog( this.s.dt, 1, "ColReorder - array reorder does not "+
-        "match known number of columns. Skipping." );
-      return;
-    }
-
-    for ( var i=0, iLen=a.length ; i<iLen ; i++ )
-    {
-      var currIndex = $.inArray( i, a );
-      if ( i != currIndex )
+      if ( a.length != this.s.dt.aoColumns.length )
       {
-        /* Reorder our switching array */
-        fnArraySwitch( a, currIndex, i );
-
-        /* Do the column reorder in the table */
-        this.s.dt.oInstance.fnColReorder( currIndex, i );
-      }
-    }
-
-    /* When scrolling we need to recalculate the column sizes to allow for the shift */
-    if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
-    {
-      this.s.dt.oInstance.fnAdjustColumnSizing();
-    }
-
-    /* Save the state */
-    this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
-
-    this._fnSetColumnIndexes();
-  },
-
-
-  /**
-   * Because we change the indexes of columns in the table, relative to their starting point
-   * we need to reorder the state columns to what they are at the starting point so we can
-   * then rearrange them again on state load!
-   *  @method  _fnStateSave
-   *  @param   object oState DataTables state
-   *  @returns string JSON encoded cookie string for DataTables
-   *  @private
-   */
-  "_fnStateSave": function ( oState )
-  {
-    var i, iLen, aCopy, iOrigColumn;
-    var oSettings = this.s.dt;
-    var columns = oSettings.aoColumns;
-
-    oState.ColReorder = [];
-
-    /* Sorting */
-    if ( oState.aaSorting ) {
-      // 1.10.0-
-      for ( i=0 ; i<oState.aaSorting.length ; i++ ) {
-        oState.aaSorting[i][0] = columns[ oState.aaSorting[i][0] ]._ColReorder_iOrigCol;
-      }
-
-      var aSearchCopy = $.extend( true, [], oState.aoSearchCols );
-
-      for ( i=0, iLen=columns.length ; i<iLen ; i++ )
-      {
-        iOrigColumn = columns[i]._ColReorder_iOrigCol;
-
-        /* Column filter */
-        oState.aoSearchCols[ iOrigColumn ] = aSearchCopy[i];
-
-        /* Visibility */
-        oState.abVisCols[ iOrigColumn ] = columns[i].bVisible;
-
-        /* Column reordering */
-        oState.ColReorder.push( iOrigColumn );
-      }
-    }
-    else if ( oState.order ) {
-      // 1.10.1+
-      for ( i=0 ; i<oState.order.length ; i++ ) {
-        oState.order[i][0] = columns[ oState.order[i][0] ]._ColReorder_iOrigCol;
-      }
-
-      var stateColumnsCopy = $.extend( true, [], oState.columns );
-
-      for ( i=0, iLen=columns.length ; i<iLen ; i++ )
-      {
-        iOrigColumn = columns[i]._ColReorder_iOrigCol;
-
-        /* Columns */
-        oState.columns[ iOrigColumn ] = stateColumnsCopy[i];
-
-        /* Column reordering */
-        oState.ColReorder.push( iOrigColumn );
-      }
-    }
-  },
-
-
-  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * Mouse drop and drag
-   */
-
-  /**
-   * Add a mouse down listener to a particluar TH element
-   *  @method  _fnMouseListener
-   *  @param   int i Column index
-   *  @param   element nTh TH element clicked on
-   *  @returns void
-   *  @private
-   */
-  "_fnMouseListener": function ( i, nTh )
-  {
-    var that = this;
-    $(nTh).on( 'mousedown.ColReorder', function (e) {
-      e.preventDefault();
-      that._fnMouseDown.call( that, e, nTh );
-    } );
-  },
-
-
-  /**
-   * Mouse down on a TH element in the table header
-   *  @method  _fnMouseDown
-   *  @param   event e Mouse event
-   *  @param   element nTh TH element to be dragged
-   *  @returns void
-   *  @private
-   */
-  "_fnMouseDown": function ( e, nTh )
-  {
-    var that = this;
-
-    /* Store information about the mouse position */
-    var target = $(e.target).closest('th, td');
-    var offset = target.offset();
-    var idx = parseInt( $(nTh).attr('data-column-index'), 10 );
-
-    if ( idx === undefined ) {
-      return;
-    }
-
-    this.s.mouse.startX = e.pageX;
-    this.s.mouse.startY = e.pageY;
-    this.s.mouse.offsetX = e.pageX - offset.left;
-    this.s.mouse.offsetY = e.pageY - offset.top;
-    this.s.mouse.target = this.s.dt.aoColumns[ idx ].nTh;//target[0];
-    this.s.mouse.targetIndex = idx;
-    this.s.mouse.fromIndex = idx;
-
-    this._fnRegions();
-
-    /* Add event handlers to the document */
-    $(document)
-      .on( 'mousemove.ColReorder', function (e) {
-        that._fnMouseMove.call( that, e );
-      } )
-      .on( 'mouseup.ColReorder', function (e) {
-        that._fnMouseUp.call( that, e );
-      } );
-  },
-
-
-  /**
-   * Deal with a mouse move event while dragging a node
-   *  @method  _fnMouseMove
-   *  @param   event e Mouse event
-   *  @returns void
-   *  @private
-   */
-  "_fnMouseMove": function ( e )
-  {
-    var that = this;
-
-    if ( this.dom.drag === null )
-    {
-      /* Only create the drag element if the mouse has moved a specific distance from the start
-       * point - this allows the user to make small mouse movements when sorting and not have a
-       * possibly confusing drag element showing up
-       */
-      if ( Math.pow(
-        Math.pow(e.pageX - this.s.mouse.startX, 2) +
-        Math.pow(e.pageY - this.s.mouse.startY, 2), 0.5 ) < 5 )
-      {
+        this.s.dt.oInstance.oApi._fnLog( this.s.dt, 1, "ColReorder - array reorder does not "+
+          "match known number of columns. Skipping." );
         return;
       }
-      this._fnCreateDragNode();
-    }
 
-    /* Position the element - we respect where in the element the click occured */
-    this.dom.drag.css( {
-      left: e.pageX - this.s.mouse.offsetX,
-      top: e.pageY - this.s.mouse.offsetY
-    } );
-
-    /* Based on the current mouse position, calculate where the insert should go */
-    var bSet = false;
-    var lastToIndex = this.s.mouse.toIndex;
-
-    for ( var i=1, iLen=this.s.aoTargets.length ; i<iLen ; i++ )
-    {
-      if ( e.pageX < this.s.aoTargets[i-1].x + ((this.s.aoTargets[i].x-this.s.aoTargets[i-1].x)/2) )
+      for ( var i=0, iLen=a.length ; i<iLen ; i++ )
       {
-        this.dom.pointer.css( 'left', this.s.aoTargets[i-1].x );
-        this.s.mouse.toIndex = this.s.aoTargets[i-1].to;
-        bSet = true;
-        break;
+        var currIndex = $.inArray( i, a );
+        if ( i != currIndex )
+        {
+          /* Reorder our switching array */
+          fnArraySwitch( a, currIndex, i );
+
+          /* Do the column reorder in the table */
+          this.s.dt.oInstance.fnColReorder( currIndex, i );
+        }
       }
-    }
-
-    // The insert element wasn't positioned in the array (less than
-    // operator), so we put it at the end
-    if ( !bSet )
-    {
-      this.dom.pointer.css( 'left', this.s.aoTargets[this.s.aoTargets.length-1].x );
-      this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length-1].to;
-    }
-
-    // Perform reordering if realtime updating is on and the column has moved
-    if ( this.s.init.bRealtime && lastToIndex !== this.s.mouse.toIndex ) {
-      this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
-      this.s.mouse.fromIndex = this.s.mouse.toIndex;
-      this._fnRegions();
-    }
-  },
-
-
-  /**
-   * Finish off the mouse drag and insert the column where needed
-   *  @method  _fnMouseUp
-   *  @param   event e Mouse event
-   *  @returns void
-   *  @private
-   */
-  "_fnMouseUp": function ( e )
-  {
-    var that = this;
-
-    $(document).off( 'mousemove.ColReorder mouseup.ColReorder' );
-
-    if ( this.dom.drag !== null )
-    {
-      /* Remove the guide elements */
-      this.dom.drag.remove();
-      this.dom.pointer.remove();
-      this.dom.drag = null;
-      this.dom.pointer = null;
-
-      /* Actually do the reorder */
-      this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
-      this._fnSetColumnIndexes();
 
       /* When scrolling we need to recalculate the column sizes to allow for the shift */
       if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
@@ -963,405 +735,633 @@ ColReorder.prototype = {
         this.s.dt.oInstance.fnAdjustColumnSizing();
       }
 
-      if ( this.s.dropCallback !== null )
-      {
-        this.s.dropCallback.call( this, this.s.mouse.fromIndex, this.s.mouse.toIndex );
-      }
-
       /* Save the state */
       this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
-    }
-  },
+
+      this._fnSetColumnIndexes();
+    },
 
 
-  /**
-   * Calculate a cached array with the points of the column inserts, and the
-   * 'to' points
-   *  @method  _fnRegions
-   *  @returns void
-   *  @private
-   */
-  "_fnRegions": function ()
-  {
-    var aoColumns = this.s.dt.aoColumns;
-
-    this.s.aoTargets.splice( 0, this.s.aoTargets.length );
-
-    this.s.aoTargets.push( {
-      "x":  $(this.s.dt.nTable).offset().left,
-      "to": 0
-    } );
-
-    var iToPoint = 0;
-    for ( var i=0, iLen=aoColumns.length ; i<iLen ; i++ )
+    /**
+     * Because we change the indexes of columns in the table, relative to their starting point
+     * we need to reorder the state columns to what they are at the starting point so we can
+     * then rearrange them again on state load!
+     *  @method  _fnStateSave
+     *  @param   object oState DataTables state
+     *  @returns string JSON encoded cookie string for DataTables
+     *  @private
+     */
+    "_fnStateSave": function ( oState )
     {
-      /* For the column / header in question, we want it's position to remain the same if the
-       * position is just to it's immediate left or right, so we only incremement the counter for
-       * other columns
-       */
-      if ( i != this.s.mouse.fromIndex )
-      {
-        iToPoint++;
+      var i, iLen, aCopy, iOrigColumn;
+      var oSettings = this.s.dt;
+      var columns = oSettings.aoColumns;
+
+      oState.ColReorder = [];
+
+      /* Sorting */
+      if ( oState.aaSorting ) {
+        // 1.10.0-
+        for ( i=0 ; i<oState.aaSorting.length ; i++ ) {
+          oState.aaSorting[i][0] = columns[ oState.aaSorting[i][0] ]._ColReorder_iOrigCol;
+        }
+
+        var aSearchCopy = $.extend( true, [], oState.aoSearchCols );
+
+        for ( i=0, iLen=columns.length ; i<iLen ; i++ )
+        {
+          iOrigColumn = columns[i]._ColReorder_iOrigCol;
+
+          /* Column filter */
+          oState.aoSearchCols[ iOrigColumn ] = aSearchCopy[i];
+
+          /* Visibility */
+          oState.abVisCols[ iOrigColumn ] = columns[i].bVisible;
+
+          /* Column reordering */
+          oState.ColReorder.push( iOrigColumn );
+        }
+      }
+      else if ( oState.order ) {
+        // 1.10.1+
+        for ( i=0 ; i<oState.order.length ; i++ ) {
+          oState.order[i][0] = columns[ oState.order[i][0] ]._ColReorder_iOrigCol;
+        }
+
+        var stateColumnsCopy = $.extend( true, [], oState.columns );
+
+        for ( i=0, iLen=columns.length ; i<iLen ; i++ )
+        {
+          iOrigColumn = columns[i]._ColReorder_iOrigCol;
+
+          /* Columns */
+          oState.columns[ iOrigColumn ] = stateColumnsCopy[i];
+
+          /* Column reordering */
+          oState.ColReorder.push( iOrigColumn );
+        }
+      }
+    },
+
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Mouse drop and drag
+     */
+
+    /**
+     * Add a mouse down listener to a particluar TH element
+     *  @method  _fnMouseListener
+     *  @param   int i Column index
+     *  @param   element nTh TH element clicked on
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseListener": function ( i, nTh )
+    {
+      var that = this;
+      $(nTh).on( 'mousedown.ColReorder', function (e) {
+        e.preventDefault();
+        that._fnMouseDown.call( that, e, nTh );
+      } );
+    },
+
+
+    /**
+     * Mouse down on a TH element in the table header
+     *  @method  _fnMouseDown
+     *  @param   event e Mouse event
+     *  @param   element nTh TH element to be dragged
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseDown": function ( e, nTh )
+    {
+      var that = this;
+
+      /* Store information about the mouse position */
+      var target = $(e.target).closest('th, td');
+      var offset = target.offset();
+      var idx = parseInt( $(nTh).attr('data-column-index'), 10 );
+
+      if ( idx === undefined ) {
+        return;
       }
 
-      if ( aoColumns[i].bVisible )
-      {
-        this.s.aoTargets.push( {
-          "x":  $(aoColumns[i].nTh).offset().left + $(aoColumns[i].nTh).outerWidth(),
-          "to": iToPoint
+      this.s.mouse.startX = e.pageX;
+      this.s.mouse.startY = e.pageY;
+      this.s.mouse.offsetX = e.pageX - offset.left;
+      this.s.mouse.offsetY = e.pageY - offset.top;
+      this.s.mouse.target = this.s.dt.aoColumns[ idx ].nTh;//target[0];
+      this.s.mouse.targetIndex = idx;
+      this.s.mouse.fromIndex = idx;
+
+      this._fnRegions();
+
+      /* Add event handlers to the document */
+      $(document)
+        .on( 'mousemove.ColReorder', function (e) {
+          that._fnMouseMove.call( that, e );
+        } )
+        .on( 'mouseup.ColReorder', function (e) {
+          that._fnMouseUp.call( that, e );
         } );
+    },
+
+
+    /**
+     * Deal with a mouse move event while dragging a node
+     *  @method  _fnMouseMove
+     *  @param   event e Mouse event
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseMove": function ( e )
+    {
+      var that = this;
+
+      if ( this.dom.drag === null )
+      {
+        /* Only create the drag element if the mouse has moved a specific distance from the start
+         * point - this allows the user to make small mouse movements when sorting and not have a
+         * possibly confusing drag element showing up
+         */
+        if ( Math.pow(
+          Math.pow(e.pageX - this.s.mouse.startX, 2) +
+          Math.pow(e.pageY - this.s.mouse.startY, 2), 0.5 ) < 5 )
+        {
+          return;
+        }
+        this._fnCreateDragNode();
       }
-    }
 
-    /* Disallow columns for being reordered by drag and drop, counting right to left */
-    if ( this.s.fixedRight !== 0 )
+      /* Position the element - we respect where in the element the click occured */
+      this.dom.drag.css( {
+        left: e.pageX - this.s.mouse.offsetX,
+        top: e.pageY - this.s.mouse.offsetY
+      } );
+
+      /* Based on the current mouse position, calculate where the insert should go */
+      var bSet = false;
+      var lastToIndex = this.s.mouse.toIndex;
+
+      for ( var i=1, iLen=this.s.aoTargets.length ; i<iLen ; i++ )
+      {
+        if ( e.pageX < this.s.aoTargets[i-1].x + ((this.s.aoTargets[i].x-this.s.aoTargets[i-1].x)/2) )
+        {
+          this.dom.pointer.css( 'left', this.s.aoTargets[i-1].x );
+          this.s.mouse.toIndex = this.s.aoTargets[i-1].to;
+          bSet = true;
+          break;
+        }
+      }
+
+      // The insert element wasn't positioned in the array (less than
+      // operator), so we put it at the end
+      if ( !bSet )
+      {
+        this.dom.pointer.css( 'left', this.s.aoTargets[this.s.aoTargets.length-1].x );
+        this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length-1].to;
+      }
+
+      // Perform reordering if realtime updating is on and the column has moved
+      if ( this.s.init.bRealtime && lastToIndex !== this.s.mouse.toIndex ) {
+        this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
+        this.s.mouse.fromIndex = this.s.mouse.toIndex;
+        this._fnRegions();
+      }
+    },
+
+
+    /**
+     * Finish off the mouse drag and insert the column where needed
+     *  @method  _fnMouseUp
+     *  @param   event e Mouse event
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseUp": function ( e )
     {
-      this.s.aoTargets.splice( this.s.aoTargets.length - this.s.fixedRight );
-    }
+      var that = this;
 
-    /* Disallow columns for being reordered by drag and drop, counting left to right */
-    if ( this.s.fixed !== 0 )
+      $(document).off( 'mousemove.ColReorder mouseup.ColReorder' );
+
+      if ( this.dom.drag !== null )
+      {
+        /* Remove the guide elements */
+        this.dom.drag.remove();
+        this.dom.pointer.remove();
+        this.dom.drag = null;
+        this.dom.pointer = null;
+
+        /* Actually do the reorder */
+        this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
+        this._fnSetColumnIndexes();
+
+        /* When scrolling we need to recalculate the column sizes to allow for the shift */
+        if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
+        {
+          this.s.dt.oInstance.fnAdjustColumnSizing();
+        }
+
+        if ( this.s.dropCallback !== null )
+        {
+          this.s.dropCallback.call( this, this.s.mouse.fromIndex, this.s.mouse.toIndex );
+        }
+
+        /* Save the state */
+        this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
+      }
+    },
+
+
+    /**
+     * Calculate a cached array with the points of the column inserts, and the
+     * 'to' points
+     *  @method  _fnRegions
+     *  @returns void
+     *  @private
+     */
+    "_fnRegions": function ()
     {
-      this.s.aoTargets.splice( 0, this.s.fixed );
-    }
-  },
+      var aoColumns = this.s.dt.aoColumns;
+
+      this.s.aoTargets.splice( 0, this.s.aoTargets.length );
+
+      this.s.aoTargets.push( {
+        "x":  $(this.s.dt.nTable).offset().left,
+        "to": 0
+      } );
+
+      var iToPoint = 0;
+      for ( var i=0, iLen=aoColumns.length ; i<iLen ; i++ )
+      {
+        /* For the column / header in question, we want it's position to remain the same if the
+         * position is just to it's immediate left or right, so we only incremement the counter for
+         * other columns
+         */
+        if ( i != this.s.mouse.fromIndex )
+        {
+          iToPoint++;
+        }
+
+        if ( aoColumns[i].bVisible )
+        {
+          this.s.aoTargets.push( {
+            "x":  $(aoColumns[i].nTh).offset().left + $(aoColumns[i].nTh).outerWidth(),
+            "to": iToPoint
+          } );
+        }
+      }
+
+      /* Disallow columns for being reordered by drag and drop, counting right to left */
+      if ( this.s.fixedRight !== 0 )
+      {
+        this.s.aoTargets.splice( this.s.aoTargets.length - this.s.fixedRight );
+      }
+
+      /* Disallow columns for being reordered by drag and drop, counting left to right */
+      if ( this.s.fixed !== 0 )
+      {
+        this.s.aoTargets.splice( 0, this.s.fixed );
+      }
+    },
 
 
-  /**
-   * Copy the TH element that is being drags so the user has the idea that they are actually
-   * moving it around the page.
-   *  @method  _fnCreateDragNode
-   *  @returns void
-   *  @private
-   */
-  "_fnCreateDragNode": function ()
-  {
-    var scrolling = this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "";
+    /**
+     * Copy the TH element that is being drags so the user has the idea that they are actually
+     * moving it around the page.
+     *  @method  _fnCreateDragNode
+     *  @returns void
+     *  @private
+     */
+    "_fnCreateDragNode": function ()
+    {
+      var scrolling = this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "";
 
-    var origCell = this.s.dt.aoColumns[ this.s.mouse.targetIndex ].nTh;
-    var origTr = origCell.parentNode;
-    var origThead = origTr.parentNode;
-    var origTable = origThead.parentNode;
-    var cloneCell = $(origCell).clone();
+      var origCell = this.s.dt.aoColumns[ this.s.mouse.targetIndex ].nTh;
+      var origTr = origCell.parentNode;
+      var origThead = origTr.parentNode;
+      var origTable = origThead.parentNode;
+      var cloneCell = $(origCell).clone();
 
-    // This is a slightly odd combination of jQuery and DOM, but it is the
-    // fastest and least resource intensive way I could think of cloning
-    // the table with just a single header cell in it.
-    this.dom.drag = $(origTable.cloneNode(false))
-      .addClass( 'DTCR_clonedTable' )
-      .append(
-        origThead.cloneNode(false).appendChild(
-          origTr.cloneNode(false).appendChild(
-            cloneCell[0]
+      // This is a slightly odd combination of jQuery and DOM, but it is the
+      // fastest and least resource intensive way I could think of cloning
+      // the table with just a single header cell in it.
+      this.dom.drag = $(origTable.cloneNode(false))
+        .addClass( 'DTCR_clonedTable' )
+        .append(
+          origThead.cloneNode(false).appendChild(
+            origTr.cloneNode(false).appendChild(
+              cloneCell[0]
+            )
           )
         )
-      )
-      .css( {
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: $(origCell).outerWidth(),
-        height: $(origCell).outerHeight()
-      } )
-      .appendTo( 'body' );
+        .css( {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: $(origCell).outerWidth(),
+          height: $(origCell).outerHeight()
+        } )
+        .appendTo( 'body' );
 
-    this.dom.pointer = $('<div></div>')
-      .addClass( 'DTCR_pointer' )
-      .css( {
-        position: 'absolute',
-        top: scrolling ?
-          $('div.dataTables_scroll', this.s.dt.nTableWrapper).offset().top :
-          $(this.s.dt.nTable).offset().top,
-        height : scrolling ?
-          $('div.dataTables_scroll', this.s.dt.nTableWrapper).height() :
-          $(this.s.dt.nTable).height()
-      } )
-      .appendTo( 'body' );
-  },
-
-  /**
-   * Clean up ColReorder memory references and event handlers
-   *  @method  _fnDestroy
-   *  @returns void
-   *  @private
-   */
-  "_fnDestroy": function ()
-  {
-    var i, iLen;
-
-    for ( i=0, iLen=this.s.dt.aoDrawCallback.length ; i<iLen ; i++ )
-    {
-      if ( this.s.dt.aoDrawCallback[i].sName === 'ColReorder_Pre' )
-      {
-        this.s.dt.aoDrawCallback.splice( i, 1 );
-        break;
-      }
-    }
-
-    $(this.s.dt.nTHead).find( '*' ).off( '.ColReorder' );
-
-    $.each( this.s.dt.aoColumns, function (i, column) {
-      $(column.nTh).removeAttr('data-column-index');
-    } );
-
-    this.s.dt._colReorder = null;
-    this.s = null;
-  },
-
-
-  /**
-   * Add a data attribute to the column headers, so we know the index of
-   * the row to be reordered. This allows fast detection of the index, and
-   * for this plug-in to work with FixedHeader which clones the nodes.
-   *  @private
-   */
-  "_fnSetColumnIndexes": function ()
-  {
-    $.each( this.s.dt.aoColumns, function (i, column) {
-      $(column.nTh).attr('data-column-index', i);
-    } );
-  }
-};
-
-
-
-
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * Static parameters
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-
-/**
- * ColReorder default settings for initialisation
- *  @namespace
- *  @static
- */
-ColReorder.defaults = {
-  /**
-   * Predefined ordering for the columns that will be applied automatically
-   * on initialisation. If not specified then the order that the columns are
-   * found to be in the HTML is the order used.
-   *  @type array
-   *  @default null
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "aiOrder": [ 4, 3, 2, 1, 0 ]
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "aiOrder": [ 4, 3, 2, 1, 0 ]
-   *      } );
-   */
-  aiOrder: null,
-
-  /**
-   * Redraw the table's column ordering as the end user draws the column
-   * (`true`) or wait until the mouse is released (`false` - default). Note
-   * that this will perform a redraw on each reordering, which involves an
-   * Ajax request each time if you are using server-side processing in
-   * DataTables.
-   *  @type boolean
-   *  @default false
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "bRealtime": true
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "bRealtime": true
-   *      } );
-   */
-  bRealtime: false,
-
-  /**
-   * Indicate how many columns should be fixed in position (counting from the
-   * left). This will typically be 1 if used, but can be as high as you like.
-   *  @type int
-   *  @default 0
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "iFixedColumns": 1
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "iFixedColumns": 1
-   *      } );
-   */
-  iFixedColumns: 0,
-
-  /**
-   * As `iFixedColumnsRight` but counting from the right.
-   *  @type int
-   *  @default 0
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "iFixedColumnsRight": 1
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "iFixedColumnsRight": 1
-   *      } );
-   */
-  iFixedColumnsRight: 0,
-
-  /**
-   * Callback function that is fired when columns are reordered
-   *  @type function():void
-   *  @default null
-   *  @static
-   *  @example
-   *      // Using the `oColReorder` option in the DataTables options object
-   *      $('#example').dataTable( {
-   *          "sDom": 'Rlfrtip',
-   *          "oColReorder": {
-   *              "fnReorderCallback": function () {
-   *                  alert( 'Columns reordered' );
-   *              }
-   *          }
-   *      } );
-   *
-   *  @example
-   *      // Using `new` constructor
-   *      $('#example').dataTable()
-   *
-   *      new $.fn.dataTable.ColReorder( '#example', {
-   *          "fnReorderCallback": function () {
-   *              alert( 'Columns reordered' );
-   *          }
-   *      } );
-   */
-  fnReorderCallback: null
-};
-
-
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * Constants
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-/**
- * ColReorder version
- *  @constant  version
- *  @type      String
- *  @default   As code
- */
-ColReorder.version = "1.1.3-dev";
-
-
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * DataTables interfaces
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-// Expose
-$.fn.dataTable.ColReorder = ColReorder;
-$.fn.DataTable.ColReorder = ColReorder;
-
-
-// Register a new feature with DataTables
-if ( typeof $.fn.dataTable == "function" &&
-     typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
-     $.fn.dataTableExt.fnVersionCheck('1.9.3') )
-{
-  $.fn.dataTableExt.aoFeatures.push( {
-    "fnInit": function( settings ) {
-      var table = settings.oInstance;
-
-      if ( ! settings._colReorder ) {
-        var dtInit = settings.oInit;
-        var opts = dtInit.colReorder || dtInit.oColReorder || {};
-
-        new ColReorder( settings, opts );
-      }
-      else {
-        table.oApi._fnLog( settings, 1, "ColReorder attempted to initialise twice. Ignoring second" );
-      }
-
-      return null; /* No node for DataTables to insert */
+      this.dom.pointer = $('<div></div>')
+        .addClass( 'DTCR_pointer' )
+        .css( {
+          position: 'absolute',
+          top: scrolling ?
+            $('div.dataTables_scroll', this.s.dt.nTableWrapper).offset().top :
+            $(this.s.dt.nTable).offset().top,
+          height : scrolling ?
+            $('div.dataTables_scroll', this.s.dt.nTableWrapper).height() :
+            $(this.s.dt.nTable).height()
+        } )
+        .appendTo( 'body' );
     },
-    "cFeature": "R",
-    "sFeature": "ColReorder"
-  } );
-}
-else {
-  alert( "Warning: ColReorder requires DataTables 1.9.3 or greater - www.datatables.net/download");
-}
+
+    /**
+     * Clean up ColReorder memory references and event handlers
+     *  @method  _fnDestroy
+     *  @returns void
+     *  @private
+     */
+    "_fnDestroy": function ()
+    {
+      var i, iLen;
+
+      for ( i=0, iLen=this.s.dt.aoDrawCallback.length ; i<iLen ; i++ )
+      {
+        if ( this.s.dt.aoDrawCallback[i].sName === 'ColReorder_Pre' )
+        {
+          this.s.dt.aoDrawCallback.splice( i, 1 );
+          break;
+        }
+      }
+
+      $(this.s.dt.nTHead).find( '*' ).off( '.ColReorder' );
+
+      $.each( this.s.dt.aoColumns, function (i, column) {
+        $(column.nTh).removeAttr('data-column-index');
+      } );
+
+      this.s.dt._colReorder = null;
+      this.s = null;
+    },
 
 
-// API augmentation
-if ( $.fn.dataTable.Api ) {
-  $.fn.dataTable.Api.register( 'colReorder.reset()', function () {
-    return this.iterator( 'table', function ( ctx ) {
-      ctx._colReorder.fnReset();
-    } );
-  } );
-
-  $.fn.dataTable.Api.register( 'colReorder.order()', function ( set ) {
-    if ( set ) {
-      return this.iterator( 'table', function ( ctx ) {
-        ctx._colReorder.fnOrder( set );
+    /**
+     * Add a data attribute to the column headers, so we know the index of
+     * the row to be reordered. This allows fast detection of the index, and
+     * for this plug-in to work with FixedHeader which clones the nodes.
+     *  @private
+     */
+    "_fnSetColumnIndexes": function ()
+    {
+      $.each( this.s.dt.aoColumns, function (i, column) {
+        $(column.nTh).attr('data-column-index', i);
       } );
     }
-
-    return this.context.length ?
-      this.context[0]._colReorder.fnOrder() :
-      null;
-  } );
-}
-
-return ColReorder;
-}; // /factory
+  };
 
 
-// Define as an AMD module if possible
-if ( typeof define === 'function' && define.amd ) {
-  define( ['jquery', 'datatables'], factory );
-}
-else if ( typeof exports === 'object' ) {
-    // Node/CommonJS
-    factory( require('jquery'), require('datatables') );
-}
-else if ( jQuery && !jQuery.fn.dataTable.ColReorder ) {
-  // Otherwise simply initialise as normal, stopping multiple evaluation
-  factory( jQuery, jQuery.fn.dataTable );
-}
+
+
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * Static parameters
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+
+  /**
+   * ColReorder default settings for initialisation
+   *  @namespace
+   *  @static
+   */
+  ColReorder.defaults = {
+    /**
+     * Predefined ordering for the columns that will be applied automatically
+     * on initialisation. If not specified then the order that the columns are
+     * found to be in the HTML is the order used.
+     *  @type array
+     *  @default null
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "aiOrder": [ 4, 3, 2, 1, 0 ]
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "aiOrder": [ 4, 3, 2, 1, 0 ]
+     *      } );
+     */
+    aiOrder: null,
+
+    /**
+     * Redraw the table's column ordering as the end user draws the column
+     * (`true`) or wait until the mouse is released (`false` - default). Note
+     * that this will perform a redraw on each reordering, which involves an
+     * Ajax request each time if you are using server-side processing in
+     * DataTables.
+     *  @type boolean
+     *  @default false
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "bRealtime": true
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "bRealtime": true
+     *      } );
+     */
+    bRealtime: false,
+
+    /**
+     * Indicate how many columns should be fixed in position (counting from the
+     * left). This will typically be 1 if used, but can be as high as you like.
+     *  @type int
+     *  @default 0
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "iFixedColumns": 1
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "iFixedColumns": 1
+     *      } );
+     */
+    iFixedColumns: 0,
+
+    /**
+     * As `iFixedColumnsRight` but counting from the right.
+     *  @type int
+     *  @default 0
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "iFixedColumnsRight": 1
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "iFixedColumnsRight": 1
+     *      } );
+     */
+    iFixedColumnsRight: 0,
+
+    /**
+     * Callback function that is fired when columns are reordered
+     *  @type function():void
+     *  @default null
+     *  @static
+     *  @example
+     *      // Using the `oColReorder` option in the DataTables options object
+     *      $('#example').dataTable( {
+     *          "sDom": 'Rlfrtip',
+     *          "oColReorder": {
+     *              "fnReorderCallback": function () {
+     *                  alert( 'Columns reordered' );
+     *              }
+     *          }
+     *      } );
+     *
+     *  @example
+     *      // Using `new` constructor
+     *      $('#example').dataTable()
+     *
+     *      new $.fn.dataTable.ColReorder( '#example', {
+     *          "fnReorderCallback": function () {
+     *              alert( 'Columns reordered' );
+     *          }
+     *      } );
+     */
+    fnReorderCallback: null
+  };
+
+
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * Constants
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+  /**
+   * ColReorder version
+   *  @constant  version
+   *  @type      String
+   *  @default   As code
+   */
+  ColReorder.version = "1.1.3-dev";
+
+
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * DataTables interfaces
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+  // Expose
+  $.fn.dataTable.ColReorder = ColReorder;
+  $.fn.DataTable.ColReorder = ColReorder;
+
+
+  // Register a new feature with DataTables
+  if ( typeof $.fn.dataTable == "function" &&
+       typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
+       $.fn.dataTableExt.fnVersionCheck('1.9.3') )
+  {
+    $.fn.dataTableExt.aoFeatures.push( {
+      "fnInit": function( settings ) {
+        var table = settings.oInstance;
+
+        if ( ! settings._colReorder ) {
+          var dtInit = settings.oInit;
+          var opts = dtInit.colReorder || dtInit.oColReorder || {};
+
+          new ColReorder( settings, opts );
+        }
+        else {
+          table.oApi._fnLog( settings, 1, "ColReorder attempted to initialise twice. Ignoring second" );
+        }
+
+        return null; /* No node for DataTables to insert */
+      },
+      "cFeature": "R",
+      "sFeature": "ColReorder"
+    } );
+  }
+  else {
+    alert( "Warning: ColReorder requires DataTables 1.9.3 or greater - www.datatables.net/download");
+  }
+
+
+  // API augmentation
+  if ( $.fn.dataTable.Api ) {
+    $.fn.dataTable.Api.register( 'colReorder.reset()', function () {
+      return this.iterator( 'table', function ( ctx ) {
+        ctx._colReorder.fnReset();
+      } );
+    } );
+
+    $.fn.dataTable.Api.register( 'colReorder.order()', function ( set ) {
+      if ( set ) {
+        return this.iterator( 'table', function ( ctx ) {
+          ctx._colReorder.fnOrder( set );
+        } );
+      }
+
+      return this.context.length ?
+        this.context[0]._colReorder.fnOrder() :
+        null;
+    } );
+  }
+
+  return ColReorder;
+  }; // /factory
+
+
+  // Define as an AMD module if possible
+  if ( typeof define === 'function' && define.amd ) {
+    define( ['jquery', 'datatables'], factory );
+  }
+  else if ( typeof exports === 'object' ) {
+      // Node/CommonJS
+      factory( require('jquery'), require('datatables') );
+  }
+  else if ( jQuery && !jQuery.fn.dataTable.ColReorder ) {
+    // Otherwise simply initialise as normal, stopping multiple evaluation
+    factory( jQuery, jQuery.fn.dataTable );
+  }
 
 
 })(window, document);

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -1,27 +1,31 @@
-/*! ColReorder 1.1.3-dev
- * ©2010-2014 SpryMedia Ltd - datatables.net/license
+/*
+ * File:        ColReorderWithResize-1.1.0-dev2.js
+ *
+ * https://github.com/jhubble/ColReorderWithResize/blob/0aebd15b89debe9d52efe5c6b29c07703c025e3d/media/js/ColReorderWithResize.js
+ * 
+ * Version:     1.1.0-dev2 (based on commit 2a6de4e884 done on Feb 22, 2013)
+ * CVS:         $Id$
+ * Description: Allow columns to be reordered in a DataTable
+ * Author:      Allan Jardine (www.sprymedia.co.uk)
+ * Created:     Wed Sep 15 18:23:29 BST 2010
+ * Modified:    2013 feb 2013 by nlz242
+ * Language:    Javascript
+ * License:     GPL v2 or BSD 3 point style
+ * Project:     DataTables
+ * Contact:     www.sprymedia.co.uk/contact
+ *
+ * Copyright 2010-2013 Allan Jardine, all rights reserved.
+ *
+ * This source file is free software, under either the GPL v2 license or a
+ * BSD style license, available at:
+ *   http://datatables.net/license_gpl2
+ *   http://datatables.net/license_bsd
+ *
+ * Minor bug fixes by Jeremy Hubble @jeremyhubble
  */
 
-/**
- * @summary     ColReorder
- * @description Provide the ability to reorder columns in a DataTable
- * @version     1.1.3-dev
- * @file        dataTables.colReorder.js
- * @author      SpryMedia Ltd (www.sprymedia.co.uk)
- * @contact     www.sprymedia.co.uk/contact
- * @copyright   Copyright 2010-2014 SpryMedia Ltd.
- *
- * This source file is free software, available under the following license:
- *   MIT license - http://datatables.net/license/mit
- *
- * This source file is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the license files for details.
- *
- * For details please refer to: http://www.datatables.net
- */
 
-(function(window, document, undefined) {
+(function ($, window, document) {
 
 
   /**
@@ -31,12 +35,10 @@
    *  @param   array aIn Array to switch around
    *  @returns array
    */
-  function fnInvertKeyValues( aIn )
-  {
-    var aRet=[];
-    for ( var i=0, iLen=aIn.length ; i<iLen ; i++ )
-    {
-      aRet[ aIn[i] ] = i;
+  function fnInvertKeyValues(aIn) {
+    var aRet = [];
+    for (var i = 0, iLen = aIn.length; i < iLen; i++) {
+      aRet[aIn[i]] = i;
     }
     return aRet;
   }
@@ -50,10 +52,9 @@
    *  @param   int iTo Insert point
    *  @returns void
    */
-  function fnArraySwitch( aArray, iFrom, iTo )
-  {
-    var mStore = aArray.splice( iFrom, 1 )[0];
-    aArray.splice( iTo, 0, mStore );
+  function fnArraySwitch(aArray, iFrom, iTo) {
+    var mStore = aArray.splice(iFrom, 1)[0];
+    aArray.splice(iTo, 0, mStore);
   }
 
 
@@ -66,32 +67,32 @@
    *  @param   int Point to element the element to (before this point), can be null for append
    *  @returns void
    */
-  function fnDomSwitch( nParent, iFrom, iTo )
-  {
+  function fnDomSwitch(nParent, iFrom, iTo) {
     var anTags = [];
-    for ( var i=0, iLen=nParent.childNodes.length ; i<iLen ; i++ )
-    {
-      if ( nParent.childNodes[i].nodeType == 1 )
-      {
-        anTags.push( nParent.childNodes[i] );
+    for (var i = 0, iLen = nParent.childNodes.length; i < iLen; i++) {
+      if (nParent.childNodes[i].nodeType == 1) {
+        anTags.push(nParent.childNodes[i]);
       }
     }
-    var nStore = anTags[ iFrom ];
+    var nStore = anTags[iFrom];
 
-    if ( iTo !== null )
-    {
-      nParent.insertBefore( nStore, anTags[iTo] );
+    if (iTo !== null) {
+      nParent.insertBefore(nStore, anTags[iTo]);
     }
-    else
-    {
-      nParent.appendChild( nStore );
+    else {
+      nParent.appendChild(nStore);
     }
   }
 
 
 
-  var factory = function( $, DataTable ) {
-  "use strict";
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * DataTables plug-in API functions
+   *
+   * This are required by ColReorder in order to perform the tasks required, and also keep this
+   * code portable, to be used for other column reordering projects with DataTables, if needed.
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
 
   /**
    * Plug-in for DataTables which will reorder the internal column structure by taking the column
@@ -102,41 +103,22 @@
    *  @param   int iTo and insert it into this point
    *  @returns void
    */
-  $.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo )
-  {
-    var v110 = $.fn.dataTable.Api ? true : false;
-    var i, iLen, j, jLen, iCols=oSettings.aoColumns.length, nTrs, oCol;
-    var attrMap = function ( obj, prop, mapping ) {
-      if ( ! obj[ prop ] ) {
-        return;
-      }
-
-      var a = obj[ prop ].split('.');
-      var num = a.shift();
-
-      if ( isNaN( num*1 ) ) {
-        return;
-      }
-
-      obj[ prop ] = mapping[ num*1 ]+'.'+a.join('.');
-    };
+  $.fn.dataTableExt.oApi.fnColReorder = function (oSettings, iFrom, iTo) {
+    var i, iLen, j, jLen, iCols = oSettings.aoColumns.length, nTrs, oCol;
 
     /* Sanity check in the input */
-    if ( iFrom == iTo )
-    {
+    if (iFrom == iTo) {
       /* Pointless reorder */
       return;
     }
 
-    if ( iFrom < 0 || iFrom >= iCols )
-    {
-      this.oApi._fnLog( oSettings, 1, "ColReorder 'from' index is out of bounds: "+iFrom );
+    if (iFrom < 0 || iFrom >= iCols) {
+      this.oApi._fnLog(oSettings, 1, "ColReorder 'from' index is out of bounds: " + iFrom);
       return;
     }
 
-    if ( iTo < 0 || iTo >= iCols )
-    {
-      this.oApi._fnLog( oSettings, 1, "ColReorder 'to' index is out of bounds: "+iTo );
+    if (iTo < 0 || iTo >= iCols) {
+      this.oApi._fnLog(oSettings, 1, "ColReorder 'to' index is out of bounds: " + iTo);
       return;
     }
 
@@ -144,74 +126,33 @@
      * Calculate the new column array index, so we have a mapping between the old and new
      */
     var aiMapping = [];
-    for ( i=0, iLen=iCols ; i<iLen ; i++ )
-    {
+    for (i = 0, iLen = iCols; i < iLen; i++) {
       aiMapping[i] = i;
     }
-    fnArraySwitch( aiMapping, iFrom, iTo );
-    var aiInvertMapping = fnInvertKeyValues( aiMapping );
+    fnArraySwitch(aiMapping, iFrom, iTo);
+    var aiInvertMapping = fnInvertKeyValues(aiMapping);
 
 
     /*
      * Convert all internal indexing to the new column order indexes
      */
     /* Sorting */
-    for ( i=0, iLen=oSettings.aaSorting.length ; i<iLen ; i++ )
-    {
-      oSettings.aaSorting[i][0] = aiInvertMapping[ oSettings.aaSorting[i][0] ];
+    for (i = 0, iLen = oSettings.aaSorting.length; i < iLen; i++) {
+      oSettings.aaSorting[i][0] = aiInvertMapping[oSettings.aaSorting[i][0]];
     }
 
     /* Fixed sorting */
-    if ( oSettings.aaSortingFixed !== null )
-    {
-      for ( i=0, iLen=oSettings.aaSortingFixed.length ; i<iLen ; i++ )
-      {
-        oSettings.aaSortingFixed[i][0] = aiInvertMapping[ oSettings.aaSortingFixed[i][0] ];
+    if (oSettings.aaSortingFixed !== null) {
+      for (i = 0, iLen = oSettings.aaSortingFixed.length; i < iLen; i++) {
+        oSettings.aaSortingFixed[i][0] = aiInvertMapping[oSettings.aaSortingFixed[i][0]];
       }
     }
 
     /* Data column sorting (the column which the sort for a given column should take place on) */
-    for ( i=0, iLen=iCols ; i<iLen ; i++ )
-    {
+    for (i = 0, iLen = iCols; i < iLen; i++) {
       oCol = oSettings.aoColumns[i];
-      for ( j=0, jLen=oCol.aDataSort.length ; j<jLen ; j++ )
-      {
-        oCol.aDataSort[j] = aiInvertMapping[ oCol.aDataSort[j] ];
-      }
-
-      // Update the column indexes
-      if ( v110 ) {
-        oCol.idx = aiInvertMapping[ oCol.idx ];
-      }
-    }
-
-    if ( v110 ) {
-      // Update 1.10 optimised sort class removal variable
-      $.each( oSettings.aLastSort, function (i, val) {
-        oSettings.aLastSort[i].src = aiInvertMapping[ val.src ];
-      } );
-    }
-
-    /* Update the Get and Set functions for each column */
-    for ( i=0, iLen=iCols ; i<iLen ; i++ )
-    {
-      oCol = oSettings.aoColumns[i];
-
-      if ( typeof oCol.mData == 'number' ) {
-        oCol.mData = aiInvertMapping[ oCol.mData ];
-
-        // regenerate the get / set functions
-        oSettings.oApi._fnColumnOptions( oSettings, i, {} );
-      }
-      else if ( $.isPlainObject( oCol.mData ) ) {
-        // HTML5 data sourced
-        attrMap( oCol.mData, '_',      aiInvertMapping );
-        attrMap( oCol.mData, 'filter', aiInvertMapping );
-        attrMap( oCol.mData, 'sort',   aiInvertMapping );
-        attrMap( oCol.mData, 'type',   aiInvertMapping );
-
-        // regenerate the get / set functions
-        oSettings.oApi._fnColumnOptions( oSettings, i, {} );
+      for (j = 0, jLen = oCol.aDataSort.length; j < jLen; j++) {
+        oCol.aDataSort[j] = aiInvertMapping[oCol.aDataSort[j]];
       }
     }
 
@@ -219,124 +160,93 @@
     /*
      * Move the DOM elements
      */
-    if ( oSettings.aoColumns[iFrom].bVisible )
-    {
+    if (oSettings.aoColumns[iFrom].bVisible) {
       /* Calculate the current visible index and the point to insert the node before. The insert
        * before needs to take into account that there might not be an element to insert before,
        * in which case it will be null, and an appendChild should be used
        */
-      var iVisibleIndex = this.oApi._fnColumnIndexToVisible( oSettings, iFrom );
+      var iVisibleIndex = this.oApi._fnColumnIndexToVisible(oSettings, iFrom);
       var iInsertBeforeIndex = null;
 
       i = iTo < iFrom ? iTo : iTo + 1;
-      while ( iInsertBeforeIndex === null && i < iCols )
-      {
-        iInsertBeforeIndex = this.oApi._fnColumnIndexToVisible( oSettings, i );
+      while (iInsertBeforeIndex === null && i < iCols) {
+        iInsertBeforeIndex = this.oApi._fnColumnIndexToVisible(oSettings, i);
         i++;
       }
 
       /* Header */
       nTrs = oSettings.nTHead.getElementsByTagName('tr');
-      for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
-      {
-        fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+      for (i = 0, iLen = nTrs.length; i < iLen; i++) {
+        fnDomSwitch(nTrs[i], iVisibleIndex, iInsertBeforeIndex);
       }
 
       /* Footer */
-      if ( oSettings.nTFoot !== null )
-      {
+      if (oSettings.nTFoot !== null) {
         nTrs = oSettings.nTFoot.getElementsByTagName('tr');
-        for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
-        {
-          fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+        for (i = 0, iLen = nTrs.length; i < iLen; i++) {
+          fnDomSwitch(nTrs[i], iVisibleIndex, iInsertBeforeIndex);
         }
       }
 
       /* Body */
-      for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
-      {
-        if ( oSettings.aoData[i].nTr !== null )
-        {
-          fnDomSwitch( oSettings.aoData[i].nTr, iVisibleIndex, iInsertBeforeIndex );
+      for (i = 0, iLen = oSettings.aoData.length; i < iLen; i++) {
+        if (oSettings.aoData[i].nTr !== null) {
+          fnDomSwitch(oSettings.aoData[i].nTr, iVisibleIndex, iInsertBeforeIndex);
         }
       }
     }
+
 
     /*
      * Move the internal array elements
      */
     /* Columns */
-    fnArraySwitch( oSettings.aoColumns, iFrom, iTo );
+    fnArraySwitch(oSettings.aoColumns, iFrom, iTo);
 
     /* Search columns */
-    fnArraySwitch( oSettings.aoPreSearchCols, iFrom, iTo );
+    fnArraySwitch(oSettings.aoPreSearchCols, iFrom, iTo);
 
     /* Array array - internal data anodes cache */
-    for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
-    {
-      var data = oSettings.aoData[i];
-
-      if ( v110 ) {
-        // DataTables 1.10+
-        if ( data.anCells ) {
-          fnArraySwitch( data.anCells, iFrom, iTo );
-        }
-
-        // For DOM sourced data, the invalidate will reread the cell into
-        // the data array, but for data sources as an array, they need to
-        // be flipped
-        if ( data.src !== 'dom' && $.isArray( data._aData ) ) {
-          fnArraySwitch( data._aData, iFrom, iTo );
-        }
-      }
-      else {
-        // DataTables 1.9-
-        if ( $.isArray( data._aData ) ) {
-          fnArraySwitch( data._aData, iFrom, iTo );
-        }
-        fnArraySwitch( data._anHidden, iFrom, iTo );
-      }
+    for (i = 0, iLen = oSettings.aoData.length; i < iLen; i++) {
+      fnArraySwitch(oSettings.aoData[i]._anHidden, iFrom, iTo);
     }
 
     /* Reposition the header elements in the header layout array */
-    for ( i=0, iLen=oSettings.aoHeader.length ; i<iLen ; i++ )
-    {
-      fnArraySwitch( oSettings.aoHeader[i], iFrom, iTo );
+    for (i = 0, iLen = oSettings.aoHeader.length; i < iLen; i++) {
+      fnArraySwitch(oSettings.aoHeader[i], iFrom, iTo);
     }
 
-    if ( oSettings.aoFooter !== null )
-    {
-      for ( i=0, iLen=oSettings.aoFooter.length ; i<iLen ; i++ )
-      {
-        fnArraySwitch( oSettings.aoFooter[i], iFrom, iTo );
+    if (oSettings.aoFooter !== null) {
+      for (i = 0, iLen = oSettings.aoFooter.length; i < iLen; i++) {
+        fnArraySwitch(oSettings.aoFooter[i], iFrom, iTo);
       }
     }
 
-    // In 1.10 we need to invalidate row cached data for sorting, filtering etc
-    if ( v110 ) {
-      var api = new $.fn.dataTable.Api( oSettings );
-      api.rows().invalidate();
-    }
 
     /*
      * Update DataTables' event handlers
      */
 
     /* Sort listener */
-    for ( i=0, iLen=iCols ; i<iLen ; i++ )
-    {
-      $(oSettings.aoColumns[i].nTh).off('click.DT');
-      this.oApi._fnSortAttachListener( oSettings, oSettings.aoColumns[i].nTh, i );
+    for (i = 0, iLen = iCols; i < iLen; i++) {
+      $(oSettings.aoColumns[i].nTh).off('click');
+      this.oApi._fnSortAttachListener(oSettings, oSettings.aoColumns[i].nTh, i);
     }
 
 
     /* Fire an event so other plug-ins can update */
-    $(oSettings.oInstance).trigger( 'column-reorder', [ oSettings, {
+    $(oSettings.oInstance).trigger('column-reorder', [oSettings, {
       "iFrom": iFrom,
       "iTo": iTo,
       "aiInvertMapping": aiInvertMapping
-    } ] );
+    }]);
+
+    if (typeof oSettings.oInstance._oPluginFixedHeader != 'undefined') {
+      oSettings.oInstance._oPluginFixedHeader.fnUpdate();
+    }
   };
+
+
 
 
   /**
@@ -346,33 +256,40 @@
    * @param {object} dt DataTables settings object
    * @param {object} opts ColReorder options
    */
-  var ColReorder = function( dt, opts )
-  {
+  var ColReorder = function (dt, opts) {
+    $(dt.nTableWrapper).width($(dt.nTable).width());
+    // make sure the headers are the same width as the rest of table
+    dt.aoDrawCallback.push({
+      "fn": function ( oSettings ) {
+        $(oSettings.nTableWrapper).width($(oSettings.nTable).width());
+      },
+      "sName": "Resize headers"
+    });
     var oDTSettings;
+    // Set the table to minimum size so that it doesn't stretch too far
+    $(dt.nTable).width("10px");
 
-    if ( $.fn.dataTable.Api ) {
-      oDTSettings = new $.fn.dataTable.Api( dt ).settings()[0];
-    }
-    // 1.9 compatibility
-    else if ( dt.fnSettings ) {
+
+    // @todo - This should really be a static method offered by DataTables
+    if (dt.fnSettings) {
       // DataTables object, convert to the settings object
       oDTSettings = dt.fnSettings();
     }
-    else if ( typeof dt === 'string' ) {
+    else if (typeof dt === 'string') {
       // jQuery selector
-      if ( $.fn.dataTable.fnIsDataTable( $(dt)[0] ) ) {
+      if ($.fn.dataTable.fnIsDataTable($(dt)[0])) {
         oDTSettings = $(dt).eq(0).dataTable().fnSettings();
       }
     }
-    else if ( dt.nodeName && dt.nodeName.toLowerCase() === 'table' ) {
+    else if (dt.nodeName && dt.nodeName.toLowerCase() === 'table') {
       // Table node
-      if ( $.fn.dataTable.fnIsDataTable( dt.nodeName ) ) {
+      if ($.fn.dataTable.fnIsDataTable(dt.nodeName)) {
         oDTSettings = $(dt.nodeName).dataTable().fnSettings();
       }
     }
-    else if ( dt instanceof jQuery ) {
+    else if (dt instanceof jQuery) {
       // jQuery object
-      if ( $.fn.dataTable.fnIsDataTable( dt[0] ) ) {
+      if ($.fn.dataTable.fnIsDataTable(dt[0])) {
         oDTSettings = dt.eq(0).dataTable().fnSettings();
       }
     }
@@ -381,18 +298,16 @@
       oDTSettings = dt;
     }
 
-    // Ensure that we can't initialise on the same table twice
-    if ( oDTSettings._colReorder ) {
-      throw "ColReorder already initialised on table #"+oDTSettings.nTable.id;
-    }
+    if (this instanceof ColReorder === false) {
+      // Get a ColReorder instance - effectively a static method
+      for (var i = 0, iLen = ColReorder.aoInstances.length; i < iLen; i++) {
+        if (ColReorder.aoInstances[i].s.dt == oDTSettings) {
+          return ColReorder.aoInstances[i];
+        }
+      }
 
-    // Convert from camelCase to Hungarian, just as DataTables does
-    var camelToHungarian = $.fn.dataTable.camelToHungarian;
-    if ( camelToHungarian ) {
-      camelToHungarian( ColReorder.defaults, ColReorder.defaults, true );
-      camelToHungarian( ColReorder.defaults, opts || {} );
+      return null;
     }
-
 
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
      * Public class variables
@@ -416,7 +331,43 @@
        *  @type     object
        *  @default  {}
        */
-      "init": $.extend( true, {}, ColReorder.defaults, opts ),
+      "init": $.extend(true, {}, ColReorder.defaults, opts),
+
+      /**
+       * Allow Reorder functionnality
+       *  @property allowReorder
+       *  @type     boolean
+       *  @default  true
+       */
+      "allowReorder": true,
+
+      /**
+       * Expand or collapse columns based on header double clicks
+       *  @property allowHeaderDoubleClick
+       *  @type     boolean
+       *  @default  true
+       */
+      "allowHeaderDoubleClick": true,
+
+      /**
+       * Expand or collapse columns based on header double clicks
+       * If set to true will use the default menu
+       * - If set to false, no context menu will be used
+       * - If set to true, the default context menu will be used
+       * - If given a function, that function will be called
+       *  @property headerContextMenu
+       *  @type     boolean/function
+       *  @default  true
+       */
+      "headerContextMenu": true,
+
+      /**
+       * Allow Resize functionnality
+       *  @property allowResize
+       *  @type     boolean
+       *  @default  true
+       */
+      "allowResize": true,
 
       /**
        * Number of columns to fix (not allow to be reordered)
@@ -464,7 +415,49 @@
        *  @type     array
        *  @default  []
        */
-      "aoTargets": []
+      "aoTargets": [],
+
+      /**
+       * Minimum width for columns (in pixels)
+       * Default is 10. If set to 0, columns can be resized to nothingness.
+       * @property minResizeWidth
+       * @type     integer
+       * @default  10
+       */
+      "minResizeWidth": 10,
+
+      /**
+       * Resize the table when columns are resized
+       * @property bResizeTable
+       * @type     bolean
+       * @default  true
+       */
+      "bResizeTable": true,
+
+
+      /**
+       * Callback called after each time the table is resized
+       * This could be multiple times on one mouse move.
+       * useful for resizing a containing element.
+       * Passed the table element, new size, and the size change
+       * @property fnResizeTableCallback
+       * @type     function
+       * @default  function(table, newSize, sizeChange) {}
+       */
+      "fnResizeTableCallback": function(){},
+
+      /**
+       * Add table-layout:fixed css to the table
+       * This header is required for column resize to function properly
+       * However, in some cases, you may want to do additional processing, and thus not set the header
+       * (For example, you may want the headers to be layed out normally, and then fix the table
+       *  after the headers are allocated their full space. In this case, you can manually add the css
+       *  in fnHeaderCallback and set bAddFixed to false here)
+       * @property bAddFixed
+       * @type     bolean
+       * @default  true
+       */
+      "bAddFixed": true
     };
 
 
@@ -481,6 +474,14 @@
       "drag": null,
 
       /**
+       * Resizing a column
+       *  @property drag
+       *  @type     element
+       *  @default  null
+       */
+      "resize": null,
+
+      /**
        * The insert cursor
        *  @property pointer
        *  @type     element
@@ -489,15 +490,23 @@
       "pointer": null
     };
 
+    this.table_size = -1;
 
     /* Constructor logic */
-    this.s.dt = oDTSettings;
-    this.s.dt._colReorder = this;
+    this.s.dt = oDTSettings.oInstance.fnSettings();
     this._fnConstruct();
 
     /* Add destroy callback */
     oDTSettings.oApi._fnCallbackReg(oDTSettings, 'aoDestroyCallback', $.proxy(this._fnDestroy, this), 'ColReorder');
 
+    /* Store the instance for later use */
+    ColReorder.aoInstances.push(this);
+
+
+    // fix the width and add table layout fixed.
+    if (this.s.bAddFixed) {
+      $(this.s.dt.nTable).width($(this.s.dt.nTable).width()).css('table-layout','fixed');
+    }
     return this;
   };
 
@@ -516,24 +525,22 @@
      *  @example
      *    // DataTables initialisation with ColReorder
      *    var table = $('#example').dataTable( {
-     *        "sDom": 'Rlfrtip'
-     *    } );
+        *        "sDom": 'Rlfrtip'
+        *    } );
      *
      *    // Add click event to a button to reset the ordering
      *    $('#resetOrdering').click( function (e) {
-     *        e.preventDefault();
-     *        $.fn.dataTable.ColReorder( table ).fnReset();
-     *    } );
+        *        e.preventDefault();
+        *        $.fn.dataTable.ColReorder( table ).fnReset();
+        *    } );
      */
-    "fnReset": function ()
-    {
+    "fnReset": function () {
       var a = [];
-      for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
-      {
-        a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
+      for (var i = 0, iLen = this.s.dt.aoColumns.length; i < iLen; i++) {
+        a.push(this.s.dt.aoColumns[i]._ColReorder_iOrigCol);
       }
 
-      this._fnOrderColumns( a );
+      this._fnOrderColumns(a);
 
       return this;
     },
@@ -544,8 +551,7 @@
      *  @deprecated `fnOrder` should be used in preference to this method.
      *      `fnOrder` acts as a getter/setter.
      */
-    "fnGetCurrentOrder": function ()
-    {
+    "fnGetCurrentOrder": function () {
       return this.fnOrder();
     },
 
@@ -559,7 +565,8 @@
      *  @example
      *    // Get column ordering for the table
      *    var order = $.fn.dataTable.ColReorder( dataTable ).fnOrder();
-     *//**
+     */
+    /**
      * Set the order of the columns, from the positions identified in the
      * ordering array given. Note that ColReorder takes a brute force approach
      * to reordering, so it is possible multiple reordering events will occur
@@ -585,22 +592,49 @@
      *      $.fn.dataTable.ColReorder( '#example' ).fnOrder().reverse()
      *    );
      */
-    "fnOrder": function ( set )
-    {
-      if ( set === undefined )
-      {
+    "fnOrder": function (set) {
+      if (set === undefined) {
         var a = [];
-        for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
-        {
-          a.push( this.s.dt.aoColumns[i]._ColReorder_iOrigCol );
+        for (var i = 0, iLen = this.s.dt.aoColumns.length; i < iLen; i++) {
+          a.push(this.s.dt.aoColumns[i]._ColReorder_iOrigCol);
         }
         return a;
       }
 
-      this._fnOrderColumns( fnInvertKeyValues( set ) );
+      this._fnOrderColumns(fnInvertKeyValues(set));
 
       return this;
     },
+
+    /**
+     * fnGetColumnSelectList - return html list of columns columns, with selected columns checked
+     *  @return {string} Html string
+     */
+    fnGetColumnSelectList : function() {
+
+      var tp,i;
+      var availableFields = this.s.dt.aoColumns;
+      var html ='<div class="selcol1">';
+      var d2 = (availableFields.length-1) /2;
+      for (i=0;i<availableFields.length;i++) {
+        tp = "col"+(i%2);
+        if (i > d2) {
+          html += '</div><div class="selcol2">';
+          d2 = 99999999;
+        }
+        var selected = availableFields[i].bVisible;
+        var title = availableFields[i].sTitle;
+        var mData = availableFields[i].mData;
+        html += '<label class="'+tp+'">'+
+          '<input name="columns" type="checkbox" checked="'+(selected ? "checked" : "")+'" value="'+mData+'">'+
+          title + '</label>';
+      }
+      html  += "</div>";
+
+      return html;
+    },
+
+
 
 
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -613,15 +647,13 @@
      *  @returns void
      *  @private
      */
-    "_fnConstruct": function ()
-    {
+    "_fnConstruct": function () {
       var that = this;
       var iLen = this.s.dt.aoColumns.length;
       var i;
 
       /* Columns discounted from reordering - counting left to right */
-      if ( this.s.init.iFixedColumns )
-      {
+      if (this.s.init.iFixedColumns) {
         this.s.fixed = this.s.init.iFixedColumns;
       }
 
@@ -631,17 +663,56 @@
         0;
 
       /* Drop callback initialisation option */
-      if ( this.s.init.fnReorderCallback )
-      {
+      if (this.s.init.fnReorderCallback) {
         this.s.dropCallback = this.s.init.fnReorderCallback;
       }
 
+      /* Allow reorder */
+      if (typeof this.s.init.allowReorder != 'undefined') {
+        this.s.allowReorder = this.s.init.allowReorder;
+      }
+
+      /* Allow resize */
+      if (typeof this.s.init.allowResize != 'undefined') {
+        this.s.allowResize = this.s.init.allowResize;
+      }
+
+      /* Allow header double click */
+      if (typeof this.s.init.allowHeaderDoubleClick != 'undefined') {
+        this.s.allowHeaderDoubleClick = this.s.init.allowHeaderDoubleClick;
+      }
+
+      /* Allow header contextmenu */
+      if (typeof this.s.init.headerContextMenu == 'function') {
+        this.s.headerContextMenu = this.s.init.headerContextMenu;
+      }
+      else if (this.s.init.headerContextMenu) {
+        this.s.headerContextMenu = this._fnDefaultContextMenu;
+      }
+      else {
+        this.s.headerContextMenu = false;
+      }
+
+      if (typeof this.s.init.minResizeWidth != 'undefined') {
+        this.s.minResizeWidth = this.s.init.minResizeWidth;
+      }
+
+      if (typeof this.s.init.bResizeTable != 'undefined') {
+        this.s.bResizeTable = this.s.init.bResizeTable;
+      }
+
+      if (typeof this.s.init.bAddFixed != 'undefined') {
+        this.s.bAddFixed = this.s.init.bAddFixed;
+      }
+
+      if (typeof this.s.init.fnResizeTableCallback == 'function') {
+        this.s.fnResizeTableCallback = this.s.init.fnResizeTableCallback;
+      }
+
       /* Add event handlers for the drag and drop, and also mark the original column order */
-      for ( i = 0; i < iLen; i++ )
-      {
-        if ( i > this.s.fixed-1 && i < iLen - this.s.fixedRight )
-        {
-          this._fnMouseListener( i, this.s.dt.aoColumns[i].nTh );
+      for (i = 0; i < iLen; i++) {
+        if (i > this.s.fixed - 1 && i < iLen - this.s.fixedRight) {
+          this._fnMouseListener(i, this.s.dt.aoColumns[i].nTh);
         }
 
         /* Mark the original column order for later reference */
@@ -649,56 +720,137 @@
       }
 
       /* State saving */
-      this.s.dt.oApi._fnCallbackReg( this.s.dt, 'aoStateSaveParams', function (oS, oData) {
-        that._fnStateSave.call( that, oData );
-      }, "ColReorder_State" );
+      this.s.dt.oApi._fnCallbackReg(this.s.dt, 'aoStateSaveParams', function (oS, oData) {
+        that._fnStateSave.call(that, oData);
+      }, "ColReorder_State");
 
       /* An initial column order has been specified */
       var aiOrder = null;
-      if ( this.s.init.aiOrder )
-      {
+      if (this.s.init.aiOrder) {
         aiOrder = this.s.init.aiOrder.slice();
       }
 
       /* State loading, overrides the column order given */
-      if ( this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
-        this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length )
-      {
+      if (this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
+        this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length) {
         aiOrder = this.s.dt.oLoadedState.ColReorder;
       }
 
-      /* If we have an order to apply - do so */
-      if ( aiOrder )
-      {
+      /* Load Column Sizes */
+      var asSizes = null;
+      if (this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColSizes != 'undefined' &&
+        this.s.dt.oLoadedState.ColSizes.length == this.s.dt.aoColumns.length) {
+        asSizes = this.s.dt.oLoadedState.ColSizes;
+      }
+
+      if (asSizes) {
+        // Apply the sizes to the column sWidth settings
+        for (i = 0, iLen = this.s.dt.aoColumns.length; i < iLen; i++)
+          this.s.dt.aoColumns[i].sWidth = asSizes[i];
+      }
+
+      /* If we have an order and/or sizing to apply - do so */
+      if (aiOrder || asSizes) {
         /* We might be called during or after the DataTables initialisation. If before, then we need
          * to wait until the draw is done, if after, then do what we need to do right away
          */
-        if ( !that.s.dt._bInitComplete )
-        {
+        if (!that.s.dt._bInitComplete) {
           var bDone = false;
-          this.s.dt.aoDrawCallback.push( {
+          this.s.dt.aoDrawCallback.push({
             "fn": function () {
-              if ( !that.s.dt._bInitComplete && !bDone )
-              {
+              if (!that.s.dt._bInitComplete && !bDone) {
                 bDone = true;
-                var resort = fnInvertKeyValues( aiOrder );
-                that._fnOrderColumns.call( that, resort );
+                if (aiOrder) {
+                  var resort = fnInvertKeyValues(aiOrder);
+                  that._fnOrderColumns.call(that, resort);
+                }
+                if (asSizes)
+                  that._fnResizeColumns.call(that);
               }
             },
             "sName": "ColReorder_Pre"
-          } );
+          });
         }
-        else
-        {
-          var resort = fnInvertKeyValues( aiOrder );
-          that._fnOrderColumns.call( that, resort );
+        else {
+          if (aiOrder) {
+            var resort = fnInvertKeyValues(aiOrder);
+            that._fnOrderColumns.call(that, resort);
+          }
+          if (asSizes)
+            that._fnResizeColumns.call(that);
         }
-      }
-      else {
-        this._fnSetColumnIndexes();
       }
     },
 
+    /**
+     * Default Context menu to display the column selectors
+     *  @method  _fnDefaultContextMenu
+     *  @param   Object e Event object of the contextmenu (right click) event
+     *  @param   Object settings The datatables settings object
+     *  @param   Object ColReorderObj The ColReorder object
+     *  @returns void
+     *  @private
+     */
+    "_fnDefaultContextMenu" : function(e,settings,thatObj) {
+      var colSelects = thatObj.fnGetColumnSelectList();
+      var myelm = $('<div></div>');
+      myelm.append(colSelects);
+      $("input",myelm).off("change").on("change", function(e) {
+        var index = $('input',myelm).index($(this));
+        var checked = $(this).is(":checked");
+        settings.oInstance.fnSetColumnVis(index,checked,true);
+      });
+
+      if (jQuery.ui) {
+        myelm.dialog({
+          "position":[e.clientX,e.clientY],
+          "title":"Select Columns",
+          "modal":true,
+          "autoOpen":true,
+          "close":function(event,ui) {
+            myelm.remove();
+          }
+        });
+      }
+      else {
+        var overlay = $('<div class="overlayDiv"></div>').appendTo("body").css({"position":"fixed",top:0,left:0, width:"100%",height:"100%","z-index":5000});
+        myelm.appendTo("body").css({position:"absolute", top:e.clientY-2, "background-color":"grey", left:e.clientX-2, "z-index":5005, "border":"1px solid black"});
+        var timer = 0;
+        myelm.mouseover(function(e) {
+          if (timer) {
+            clearTimeout(timer);
+          }
+        });
+
+        myelm.mouseout(function(e) {
+          if (timer) {
+            clearTimeout(timer);
+          }
+          timer = setTimeout(
+            function() {
+              overlay.remove();
+              myelm.remove();
+            },200);
+        });
+      }
+
+    },
+
+    /**
+     * Set the column sizes (widths) from an array
+     *  @method  _fnResizeColumns
+     *  @returns void
+     *  @private
+     */
+    "_fnResizeColumns": function () {
+      for (var i = 0, iLen = this.s.dt.aoColumns.length; i < iLen; i++) {
+        if (this.s.dt.aoColumns[i].sWidth)
+          this.s.dt.aoColumns[i].nTh.style.width = this.s.dt.aoColumns[i].sWidth;
+      }
+
+      /* Save the state */
+      // this.s.dt.oInstance.oApi._fnSaveState(this.s.dt);
+    },
 
     /**
      * Set the column order from an array
@@ -707,38 +859,31 @@
      *  @returns void
      *  @private
      */
-    "_fnOrderColumns": function ( a )
-    {
-      if ( a.length != this.s.dt.aoColumns.length )
-      {
-        this.s.dt.oInstance.oApi._fnLog( this.s.dt, 1, "ColReorder - array reorder does not "+
-          "match known number of columns. Skipping." );
+    "_fnOrderColumns": function (a) {
+      if (a.length != this.s.dt.aoColumns.length) {
+        this.s.dt.oInstance.oApi._fnLog(this.s.dt, 1, "ColReorder - array reorder does not " +
+          "match known number of columns. Skipping.");
         return;
       }
 
-      for ( var i=0, iLen=a.length ; i<iLen ; i++ )
-      {
-        var currIndex = $.inArray( i, a );
-        if ( i != currIndex )
-        {
+      for (var i = 0, iLen = a.length; i < iLen; i++) {
+        var currIndex = $.inArray(i, a);
+        if (i != currIndex) {
           /* Reorder our switching array */
-          fnArraySwitch( a, currIndex, i );
+          fnArraySwitch(a, currIndex, i);
 
           /* Do the column reorder in the table */
-          this.s.dt.oInstance.fnColReorder( currIndex, i );
+          this.s.dt.oInstance.fnColReorder(currIndex, i);
         }
       }
 
       /* When scrolling we need to recalculate the column sizes to allow for the shift */
-      if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
-      {
+      if (this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "") {
         this.s.dt.oInstance.fnAdjustColumnSizing();
       }
 
       /* Save the state */
-      this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
-
-      this._fnSetColumnIndexes();
+      this.s.dt.oInstance.oApi._fnSaveState(this.s.dt);
     },
 
 
@@ -751,55 +896,33 @@
      *  @returns string JSON encoded cookie string for DataTables
      *  @private
      */
-    "_fnStateSave": function ( oState )
-    {
+    "_fnStateSave": function (oState) {
       var i, iLen, aCopy, iOrigColumn;
       var oSettings = this.s.dt;
-      var columns = oSettings.aoColumns;
-
-      oState.ColReorder = [];
 
       /* Sorting */
-      if ( oState.aaSorting ) {
-        // 1.10.0-
-        for ( i=0 ; i<oState.aaSorting.length ; i++ ) {
-          oState.aaSorting[i][0] = columns[ oState.aaSorting[i][0] ]._ColReorder_iOrigCol;
-        }
-
-        var aSearchCopy = $.extend( true, [], oState.aoSearchCols );
-
-        for ( i=0, iLen=columns.length ; i<iLen ; i++ )
-        {
-          iOrigColumn = columns[i]._ColReorder_iOrigCol;
-
-          /* Column filter */
-          oState.aoSearchCols[ iOrigColumn ] = aSearchCopy[i];
-
-          /* Visibility */
-          oState.abVisCols[ iOrigColumn ] = columns[i].bVisible;
-
-          /* Column reordering */
-          oState.ColReorder.push( iOrigColumn );
-        }
+      for (i = 0; i < oState.aaSorting.length; i++) {
+        oState.aaSorting[i][0] = oSettings.aoColumns[oState.aaSorting[i][0]]._ColReorder_iOrigCol;
       }
-      else if ( oState.order ) {
-        // 1.10.1+
-        for ( i=0 ; i<oState.order.length ; i++ ) {
-          oState.order[i][0] = columns[ oState.order[i][0] ]._ColReorder_iOrigCol;
-        }
 
-        var stateColumnsCopy = $.extend( true, [], oState.columns );
+      var aSearchCopy = $.extend(true, [], oState.aoSearchCols);
+      oState.ColReorder = [];
+      oState.ColSizes = [];
 
-        for ( i=0, iLen=columns.length ; i<iLen ; i++ )
-        {
-          iOrigColumn = columns[i]._ColReorder_iOrigCol;
+      for (i = 0, iLen = oSettings.aoColumns.length; i < iLen; i++) {
+        iOrigColumn = oSettings.aoColumns[i]._ColReorder_iOrigCol;
 
-          /* Columns */
-          oState.columns[ iOrigColumn ] = stateColumnsCopy[i];
+        /* Column filter */
+        oState.aoSearchCols[iOrigColumn] = aSearchCopy[i];
 
-          /* Column reordering */
-          oState.ColReorder.push( iOrigColumn );
-        }
+        /* Visibility */
+        oState.abVisCols[iOrigColumn] = oSettings.aoColumns[i].bVisible;
+
+        /* Column reordering */
+        oState.ColReorder.push(iOrigColumn);
+
+        /* Column Sizes */
+        oState.ColSizes[iOrigColumn] = oSettings.aoColumns[i].sWidth;
       }
     },
 
@@ -816,13 +939,119 @@
      *  @returns void
      *  @private
      */
-    "_fnMouseListener": function ( i, nTh )
-    {
+    "_fnMouseListener": function (i, nTh) {
       var that = this;
-      $(nTh).on( 'mousedown.ColReorder', function (e) {
+
+      var thead = $(nTh).closest('thead');
+      // listen to mousemove event for resize
+      if (this.s.allowResize) {
+        //$(nTh).bind('mousemove.ColReorder', function (e) {
+        thead.bind('mousemove.ColReorder', function (e) {
+          var nTable = that.s.dt.nTable;
+          if (that.dom.drag === null && that.dom.resize === null) {
+            /* Store information about the mouse position */
+            var nThTarget = e.target.nodeName == "TH" ? e.target : $(e.target).parents('TH')[0];
+            var offset = $(nThTarget).offset();
+            var nLength = $(nThTarget).innerWidth();
+
+            /* are we on the col border (if so, resize col) */
+            if (Math.abs(e.pageX - Math.round(offset.left + nLength)) <= 5) {
+              $(nThTarget).css({ 'cursor': 'col-resize' });
+              // catch gaps between cells
+              //$(nTable).css({'cursor' : 'col-resize'});
+              that.dom.resizeCol = "right";
+            }
+            else if ((e.pageX - offset.left) < 5) {
+              $(nThTarget).css({'cursor' : 'col-resize'});
+              //$(nTable).css({'cursor' : 'col-resize'});
+              that.dom.resizeCol = "left";
+            }
+            else {
+              $(nThTarget).css({ 'cursor': 'pointer' });
+              //$(nTable).css({'cursor' : 'pointer'});
+            }
+          }
+        });
+
+
+      }
+
+      $(nTh).on('mousedown.ColReorder', function (e) {
         e.preventDefault();
-        that._fnMouseDown.call( that, e, nTh );
-      } );
+        that._fnMouseDown.call(that, e, nTh, i);
+      });
+
+      // Add doubleclick also
+      // It is best to disable sorting if using double click
+      if (this.s.allowHeaderDoubleClick) {
+        $(nTh).on("dblclick.ColReorder", function(e) {
+          e.preventDefault();
+          that._fnDblClick.call(that, e, nTh, i);
+        });
+      }
+
+      if (this.s.headerContextMenu) {
+        $(nTh).off("contextmenu.ColReorder").on("contextmenu.ColReorder", function(e) {
+          e.preventDefault();
+          that.s.headerContextMenu.call(this,e,that.s.dt,that);
+        });
+
+      }
+    },
+
+
+    /**
+     * Double click on a TH element in the table header
+     *  @method  _fnMouseDown
+     *  @param   event e Mouse event
+     *  @param   element nTh TH element to be resized
+     *  @returns void
+     *  @private
+     */
+    "_fnDblClick": function (e, nTh, index) {
+      var nTable = this.s.dt.nTable;
+      var tableWidth = $(nTable).width();
+      var aoColumns = this.s.dt.aoColumns;
+
+      var realWidths = $.map($('th',$(this.s.dt.nThead)), function(l) {return $(l).width();});
+      var nThWidth = $(nTh).width();
+      var newWidth;
+      var that = this;
+
+      var tableResizeIt = function() {
+        var newTableWidth = tableWidth + newWidth - nThWidth;
+
+        $(nTable).width(newTableWidth);
+        $(nTable).css('table-layout',"fixed");
+        $(nTh).width(newWidth);
+
+        aoColumns[index].sWidth = newWidth+"px";
+        that.s.fnResizeTableCallback(nTable,newTableWidth,newTableWidth-tableWidth);
+      };
+
+      if ($(nTh).hasClass('maxwidth')) {
+        var newHead = $(nTable).clone();
+        $('tbody', newHead).remove();
+        var newItem = $(nTh).clone();
+        newItem.wrap("<tr />");
+        newItem.wrap("<table />");
+        $(nTable).css({'table-layout':"auto","width":"auto"});
+        this.s.dt.oFeatures.bAutoWidth = true;
+        // Lets try resizing to headers instead
+        newWidth = this.s.minResizeWidth;
+        $(nTh).removeClass('maxwidth');
+      }
+
+      else {
+        $(nTable).css({'table-layout':"auto","width":"auto"});
+        newWidth = $('th',nTable).eq(index).width();
+
+        $(nTh).addClass("maxwidth");
+        tableResizeIt();
+      }
+
+
+
     },
 
 
@@ -834,37 +1063,80 @@
      *  @returns void
      *  @private
      */
-    "_fnMouseDown": function ( e, nTh )
-    {
+    "_fnMouseDown": function (e, nTh, i) {
       var that = this;
+      var target, offset, idx, nThNext, nThPrev;
+      /* are we resizing a column ? */
+      if ($(nTh).css('cursor') == 'col-resize') {
+        // are we at the right or left?
+        this.s.mouse.startX = e.pageX;
+        this.s.tableWidth = $(nTh).closest("table").width();
 
-      /* Store information about the mouse position */
-      var target = $(e.target).closest('th, td');
-      var offset = target.offset();
-      var idx = parseInt( $(nTh).attr('data-column-index'), 10 );
 
-      if ( idx === undefined ) {
-        return;
+        // If we are at the left end, we expand the previous column
+        if (this.dom.resizeCol == "left") {
+          nThPrev = $(nTh).prev();
+          this.s.mouse.startWidth = $(nThPrev).width();
+          this.s.mouse.resizeElem = $(nThPrev);
+          nThNext = $(nTh).next();
+          this.s.mouse.nextStartWidth = $(nTh).width();
+          this.s.mouse.targetIndex = $('th', nTh.parentNode).index(nThPrev);
+          this.s.mouse.fromIndex = this.s.dt.oInstance.oApi._fnVisibleToColumnIndex(this.s.dt, this.s.mouse.targetIndex);
+        }
+
+        // If we are at the right end of column, we expand the current column
+        else {
+          this.s.mouse.startWidth = $(nTh).width();
+          this.s.mouse.resizeElem = $(nTh);
+          nThNext = $(nTh).next();
+          this.s.mouse.nextStartWidth = $(nThNext).width();
+          this.s.mouse.targetIndex = $('th', nTh.parentNode).index(nTh);
+          this.s.mouse.fromIndex = this.s.dt.oInstance.oApi._fnVisibleToColumnIndex(this.s.dt, this.s.mouse.targetIndex);
+        }
+
+        that.dom.resize = true;
+        ////////////////////
+        //Martin Marchetta
+        //a. Disable column sorting so as to avoid issues when finishing column resizing
+        target = $(e.target).closest('th, td');
+        offset = target.offset();
+        idx = $.inArray(target[0], $.map(this.s.dt.aoColumns, function (o) { return o.nTh; }));
+        // store state so we don't tunr on sorting where we don't want it
+        this.s.dt.aoColumns[idx]._oldbSortable = this.s.dt.aoColumns[idx].bSortable;
+        this.s.dt.aoColumns[idx].bSortable = false;
+        //b. Disable Autowidth feature (now the user is in charge of setting column width so keeping this enabled looses changes after operations)
+        this.s.dt.oFeatures.bAutoWidth = false;
+        ////////////////////
       }
+      else if (this.s.allowReorder) {
+        that.dom.resize = null;
+        /* Store information about the mouse position */
+        target = $(e.target).closest('th, td');
+        offset = target.offset();
+        idx = $.inArray(target[0], $.map(this.s.dt.aoColumns, function (o) { return o.nTh; }));
 
-      this.s.mouse.startX = e.pageX;
-      this.s.mouse.startY = e.pageY;
-      this.s.mouse.offsetX = e.pageX - offset.left;
-      this.s.mouse.offsetY = e.pageY - offset.top;
-      this.s.mouse.target = this.s.dt.aoColumns[ idx ].nTh;//target[0];
-      this.s.mouse.targetIndex = idx;
-      this.s.mouse.fromIndex = idx;
+        if (idx === -1) {
+          return;
+        }
 
-      this._fnRegions();
+        this.s.mouse.startX = e.pageX;
+        this.s.mouse.startY = e.pageY;
+        this.s.mouse.offsetX = e.pageX - offset.left;
+        this.s.mouse.offsetY = e.pageY - offset.top;
+        this.s.mouse.target = target[0];
+        this.s.mouse.targetIndex = idx;
+        this.s.mouse.fromIndex = idx;
 
+        this._fnRegions();
+      }
       /* Add event handlers to the document */
-      $(document)
-        .on( 'mousemove.ColReorder', function (e) {
-          that._fnMouseMove.call( that, e );
-        } )
-        .on( 'mouseup.ColReorder', function (e) {
-          that._fnMouseUp.call( that, e );
-        } );
+      $(document).on('mousemove.ColReorder', function (e) {
+        that._fnMouseMove.call(that, e, i);
+      }).on('mouseup.ColReorder', function (e) {
+        setTimeout(function () {
+          that._fnMouseUp.call(that, e, i);
+        }, 10);
+      });
     },
 
 
@@ -875,59 +1147,134 @@
      *  @returns void
      *  @private
      */
-    "_fnMouseMove": function ( e )
-    {
+    "_fnMouseMove": function (e) {
       var that = this;
+      ////////////////////
+      //Martin Marchetta: Determine if ScrollX is enabled
+      var scrollXEnabled;
 
-      if ( this.dom.drag === null )
-      {
-        /* Only create the drag element if the mouse has moved a specific distance from the start
-         * point - this allows the user to make small mouse movements when sorting and not have a
-         * possibly confusing drag element showing up
-         */
-        if ( Math.pow(
-          Math.pow(e.pageX - this.s.mouse.startX, 2) +
-          Math.pow(e.pageY - this.s.mouse.startY, 2), 0.5 ) < 5 )
-        {
-          return;
+      scrollXEnabled = this.s.dt.oInit.sScrollX === "" ? false : true;
+
+      //Keep the current table's width (used in case sScrollX is enabled to resize the whole table, giving an Excel-like behavior)
+      if (this.table_size < 0 && scrollXEnabled && $('div.dataTables_scrollHead', this.s.dt.nTableWrapper) !== undefined) {
+        if ($('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length > 0)
+          this.table_size = $($('div.dataTables_scrollHead', this.s.dt.nTableWrapper)[0].childNodes[0].childNodes[0]).width();
+      }
+      ////////////////////
+
+      /* are we resizing a column ? */
+      if (this.dom.resize) {
+        var nTh = this.s.mouse.resizeElem;
+        var nThNext = $(nTh).next();
+        var moveLength = e.pageX - this.s.mouse.startX;
+        var newWidth = this.s.mouse.startWidth + moveLength;
+        // set a min width of 10 - this would be good to configure
+        if (newWidth < this.s.minResizeWidth) {
+          newWidth = this.s.minResizeWidth;
+          moveLength = newWidth - this.s.mouse.startWidth ;
         }
-        this._fnCreateDragNode();
-      }
-
-      /* Position the element - we respect where in the element the click occured */
-      this.dom.drag.css( {
-        left: e.pageX - this.s.mouse.offsetX,
-        top: e.pageY - this.s.mouse.offsetY
-      } );
-
-      /* Based on the current mouse position, calculate where the insert should go */
-      var bSet = false;
-      var lastToIndex = this.s.mouse.toIndex;
-
-      for ( var i=1, iLen=this.s.aoTargets.length ; i<iLen ; i++ )
-      {
-        if ( e.pageX < this.s.aoTargets[i-1].x + ((this.s.aoTargets[i].x-this.s.aoTargets[i-1].x)/2) )
-        {
-          this.dom.pointer.css( 'left', this.s.aoTargets[i-1].x );
-          this.s.mouse.toIndex = this.s.aoTargets[i-1].to;
-          bSet = true;
-          break;
+        if (moveLength !== 0 && !scrollXEnabled) {
+          $(nThNext).width(this.s.mouse.nextStartWidth - moveLength);
         }
-      }
+        $(nTh).width(this.s.mouse.startWidth + moveLength);
 
-      // The insert element wasn't positioned in the array (less than
-      // operator), so we put it at the end
-      if ( !bSet )
-      {
-        this.dom.pointer.css( 'left', this.s.aoTargets[this.s.aoTargets.length-1].x );
-        this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length-1].to;
-      }
+        //Martin Marchetta: Resize the header too (if sScrollX is enabled)
+        if (scrollXEnabled && $('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length) {
+          if ($('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length > 0)
+            $($('div.dataTables_scrollHead', this.s.dt.nTableWrapper)[0].childNodes[0].childNodes[0]).width(this.table_size + moveLength);
+        }
 
-      // Perform reordering if realtime updating is on and the column has moved
-      if ( this.s.init.bRealtime && lastToIndex !== this.s.mouse.toIndex ) {
-        this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
-        this.s.mouse.fromIndex = this.s.mouse.toIndex;
-        this._fnRegions();
+        ////////////////////////
+        //Martin Marchetta: Fixed col resizing when the scroller is enabled.
+        var visibleColumnIndex;
+        //First determine if this plugin is being used along with the smart scroller...
+        if ($('div.dataTables_scrollBody').lenggthll) {
+          //...if so, when resizing the header, also resize the table's body (when enabling the Scroller, the table's header and
+          //body are split into different tables, so the column resizing doesn't work anymore)
+          if ($('div.dataTables_scrollBody').length > 0) {
+            //Since some columns might have been hidden, find the correct one to resize in the table's body
+            var currentColumnIndex;
+            visibleColumnIndex = -1;
+            for (currentColumnIndex = -1; currentColumnIndex < this.s.dt.aoColumns.length - 1 && currentColumnIndex != colResized; currentColumnIndex++) {
+              if (this.s.dt.aoColumns[currentColumnIndex + 1].bVisible)
+                visibleColumnIndex++;
+            }
+
+            //Get the scroller's div
+            tableScroller = $('div.dataTables_scrollBody', this.s.dt.nTableWrapper)[0];
+
+            //Get the table
+            scrollingTableHead = $(tableScroller)[0].childNodes[0].childNodes[0].childNodes[0];
+
+            //Resize the columns
+            if (moveLength  && !scrollXEnabled) {
+              $($(scrollingTableHead)[0].childNodes[visibleColumnIndex + 1]).width(this.s.mouse.nextStartWidth - moveLength);
+            }
+            $($(scrollingTableHead)[0].childNodes[visibleColumnIndex]).width(this.s.mouse.startWidth + moveLength);
+
+            //Resize the table too
+            if (scrollXEnabled) {
+              $($(tableScroller)[0].childNodes[0]).width(this.table_size + moveLength);
+            }
+          }
+        }
+
+        if (this.s.bResizeTable) {
+          var tableMove = this.s.tableWidth + moveLength;
+          $(nTh).closest('table').width(tableMove);
+          this.s.fnResizeTableCallback($(nTh).closest('table'),tableMove,moveLength);
+        }
+
+        ////////////////////////
+
+        return;
+      }
+      else if (this.s.allowReorder) {
+        if (this.dom.drag === null) {
+          /* Only create the drag element if the mouse has moved a specific distance from the start
+           * point - this allows the user to make small mouse movements when sorting and not have a
+           * possibly confusing drag element showing up
+           */
+          if (Math.pow(
+              Math.pow(e.pageX - this.s.mouse.startX, 2) +
+              Math.pow(e.pageY - this.s.mouse.startY, 2), 0.5) < 5) {
+            return;
+          }
+          this._fnCreateDragNode();
+        }
+
+        /* Position the element - we respect where in the element the click occured */
+        this.dom.drag.css({
+          left: e.pageX - this.s.mouse.offsetX,
+          top: e.pageY - this.s.mouse.offsetY
+        });
+
+        /* Based on the current mouse position, calculate where the insert should go */
+        var bSet = false;
+        var lastToIndex = this.s.mouse.toIndex;
+
+        for (var i = 1, iLen = this.s.aoTargets.length; i < iLen; i++) {
+          if (e.pageX < this.s.aoTargets[i - 1].x + ((this.s.aoTargets[i].x - this.s.aoTargets[i - 1].x) / 2)) {
+            this.dom.pointer.css('left', this.s.aoTargets[i - 1].x);
+            this.s.mouse.toIndex = this.s.aoTargets[i - 1].to;
+            bSet = true;
+            break;
+          }
+        }
+
+        // The insert element wasn't positioned in the array (less than
+        // operator), so we put it at the end
+        if (!bSet) {
+          this.dom.pointer.css('left', this.s.aoTargets[this.s.aoTargets.length - 1].x);
+          this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length - 1].to;
+        }
+
+        // Perform reordering if realtime updating is on and the column has moved
+        if (this.s.init.bRealtime && lastToIndex !== this.s.mouse.toIndex) {
+          this.s.dt.oInstance.fnColReorder(this.s.mouse.fromIndex, this.s.mouse.toIndex);
+          this.s.mouse.fromIndex = this.s.mouse.toIndex;
+          this._fnRegions();
+        }
       }
     },
 
@@ -939,14 +1286,12 @@
      *  @returns void
      *  @private
      */
-    "_fnMouseUp": function ( e )
-    {
+    "_fnMouseUp": function (e, colResized) {
       var that = this;
 
-      $(document).off( 'mousemove.ColReorder mouseup.ColReorder' );
+      $(document).off('mousemove.ColReorder mouseup.ColReorder');
 
-      if ( this.dom.drag !== null )
-      {
+      if (this.dom.drag !== null) {
         /* Remove the guide elements */
         this.dom.drag.remove();
         this.dom.pointer.remove();
@@ -954,23 +1299,91 @@
         this.dom.pointer = null;
 
         /* Actually do the reorder */
-        this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex );
-        this._fnSetColumnIndexes();
+        this.s.dt.oInstance.fnColReorder(this.s.mouse.fromIndex, this.s.mouse.toIndex);
 
         /* When scrolling we need to recalculate the column sizes to allow for the shift */
-        if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
-        {
+        if (this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "") {
           this.s.dt.oInstance.fnAdjustColumnSizing();
         }
 
-        if ( this.s.dropCallback !== null )
-        {
-          this.s.dropCallback.call( this, this.s.mouse.fromIndex, this.s.mouse.toIndex );
+        if (this.s.dropCallback !== null) {
+          this.s.dropCallback.call(this);
         }
 
         /* Save the state */
-        this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
+        this.s.dt.oInstance.oApi._fnSaveState(this.s.dt);
       }
+      else if (this.dom.resize !== null) {
+        var i;
+        var j;
+        var column;
+        var currentColumn;
+        var aoColumnsColumnindex;
+        var nextVisibleColumnIndex;
+        var previousVisibleColumnIndex;
+        var scrollXEnabled;
+        var resizeCol = this.dom.resizeCol;
+        /*
+         if (resizeCol == 'right') {
+         colResized++;
+         }
+         */
+        for (i = 0; i < this.s.dt.aoColumns.length; i++) {
+          if (this.s.dt.aoColumns[i]._ColReorder_iOrigCol === colResized) {
+            aoColumnsColumnindex = i;
+            break;
+          }
+        }
+
+        // Re-enable column sorting
+        // only if sorting were previously enabled
+        this.s.dt.aoColumns[aoColumnsColumnindex].bSortable = this.s.dt.aoColumns[aoColumnsColumnindex]._oldbSortable;
+
+        // Save the new resized column's width
+        this.s.dt.aoColumns[aoColumnsColumnindex].sWidth = $(this.s.mouse.resizeElem).innerWidth() + "px";
+
+        // If other columns might have changed their size, save their size too
+        scrollXEnabled = this.s.dt.oInit.sScrollX === "" ? false : true;
+        if (!scrollXEnabled) {
+          //The colResized index (internal model) here might not match the visible index since some columns might have been hidden
+          for (nextVisibleColumnIndex = colResized + 1; nextVisibleColumnIndex < this.s.dt.aoColumns.length; nextVisibleColumnIndex++) {
+            if (this.s.dt.aoColumns[nextVisibleColumnIndex].bVisible)
+              break;
+          }
+
+          for (previousVisibleColumnIndex = colResized - 1; previousVisibleColumnIndex >= 0; previousVisibleColumnIndex--) {
+            if (this.s.dt.aoColumns[previousVisibleColumnIndex].bVisible)
+              break;
+          }
+
+          if (this.s.dt.aoColumns.length > nextVisibleColumnIndex)
+            this.s.dt.aoColumns[nextVisibleColumnIndex].sWidth = $(this.s.mouse.resizeElem).next().innerWidth() + "px";
+          else { //The column resized is the right-most, so save the sizes of all the columns at the left
+            currentColumn = this.s.mouse.resizeElem;
+            for (i = previousVisibleColumnIndex; i > 0; i--) {
+              if (this.s.dt.aoColumns[i].bVisible) {
+                currentColumn = $(currentColumn).prev();
+                this.s.dt.aoColumns[i].sWidth = $(currentColumn).innerWidth() + "px";
+              }
+            }
+          }
+        }
+
+        //Update the internal storage of the table's width (in case we changed it because the user resized some column and scrollX was enabled
+        if (scrollXEnabled && $('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length) {
+          if ($('div.dataTables_scrollHead', this.s.dt.nTableWrapper).length > 0) {
+            this.table_size = $($('div.dataTables_scrollHead', this.s.dt.nTableWrapper)[0].childNodes[0].childNodes[0]).width();
+          }
+        }
+
+        $(this.s.dt.nTableWrapper).width($(this.s.dt.nTable).width());
+
+        //Save the state
+        this.s.dt.oInstance.oApi._fnSaveState(this.s.dt);
+      }
+      ///////////////////////////////////////////////////////
+
+      this.dom.resize = null;
     },
 
 
@@ -981,48 +1394,42 @@
      *  @returns void
      *  @private
      */
-    "_fnRegions": function ()
-    {
+    "_fnRegions": function () {
       var aoColumns = this.s.dt.aoColumns;
 
-      this.s.aoTargets.splice( 0, this.s.aoTargets.length );
+      this.s.aoTargets.splice(0, this.s.aoTargets.length);
 
-      this.s.aoTargets.push( {
-        "x":  $(this.s.dt.nTable).offset().left,
+      this.s.aoTargets.push({
+        "x": $(this.s.dt.nTable).offset().left,
         "to": 0
-      } );
+      });
 
       var iToPoint = 0;
-      for ( var i=0, iLen=aoColumns.length ; i<iLen ; i++ )
-      {
+      for (var i = 0, iLen = aoColumns.length; i < iLen; i++) {
         /* For the column / header in question, we want it's position to remain the same if the
          * position is just to it's immediate left or right, so we only incremement the counter for
          * other columns
          */
-        if ( i != this.s.mouse.fromIndex )
-        {
+        if (i != this.s.mouse.fromIndex) {
           iToPoint++;
         }
 
-        if ( aoColumns[i].bVisible )
-        {
-          this.s.aoTargets.push( {
-            "x":  $(aoColumns[i].nTh).offset().left + $(aoColumns[i].nTh).outerWidth(),
+        if (aoColumns[i].bVisible) {
+          this.s.aoTargets.push({
+            "x": $(aoColumns[i].nTh).offset().left + $(aoColumns[i].nTh).outerWidth(),
             "to": iToPoint
-          } );
+          });
         }
       }
 
       /* Disallow columns for being reordered by drag and drop, counting right to left */
-      if ( this.s.fixedRight !== 0 )
-      {
-        this.s.aoTargets.splice( this.s.aoTargets.length - this.s.fixedRight );
+      if (this.s.fixedRight !== 0) {
+        this.s.aoTargets.splice(this.s.aoTargets.length - this.s.fixedRight);
       }
 
       /* Disallow columns for being reordered by drag and drop, counting left to right */
-      if ( this.s.fixed !== 0 )
-      {
-        this.s.aoTargets.splice( 0, this.s.fixed );
+      if (this.s.fixed !== 0) {
+        this.s.aoTargets.splice(0, this.s.fixed);
       }
     },
 
@@ -1034,11 +1441,10 @@
      *  @returns void
      *  @private
      */
-    "_fnCreateDragNode": function ()
-    {
+    "_fnCreateDragNode": function () {
       var scrolling = this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "";
 
-      var origCell = this.s.dt.aoColumns[ this.s.mouse.targetIndex ].nTh;
+      var origCell = this.s.dt.aoColumns[this.s.mouse.targetIndex].nTh;
       var origTr = origCell.parentNode;
       var origThead = origTr.parentNode;
       var origTable = origThead.parentNode;
@@ -1048,35 +1454,35 @@
       // fastest and least resource intensive way I could think of cloning
       // the table with just a single header cell in it.
       this.dom.drag = $(origTable.cloneNode(false))
-        .addClass( 'DTCR_clonedTable' )
+        .addClass('DTCR_clonedTable')
         .append(
-          origThead.cloneNode(false).appendChild(
-            origTr.cloneNode(false).appendChild(
-              cloneCell[0]
-            )
+        origThead.cloneNode(false).appendChild(
+          origTr.cloneNode(false).appendChild(
+            cloneCell[0]
           )
         )
-        .css( {
+      )
+        .css({
           position: 'absolute',
           top: 0,
           left: 0,
           width: $(origCell).outerWidth(),
           height: $(origCell).outerHeight()
-        } )
-        .appendTo( 'body' );
+        })
+        .appendTo('body');
 
       this.dom.pointer = $('<div></div>')
-        .addClass( 'DTCR_pointer' )
-        .css( {
+        .addClass('DTCR_pointer')
+        .css({
           position: 'absolute',
           top: scrolling ?
             $('div.dataTables_scroll', this.s.dt.nTableWrapper).offset().top :
             $(this.s.dt.nTable).offset().top,
-          height : scrolling ?
+          height: scrolling ?
             $('div.dataTables_scroll', this.s.dt.nTableWrapper).height() :
             $(this.s.dt.nTable).height()
-        } )
-        .appendTo( 'body' );
+        })
+        .appendTo('body');
     },
 
     /**
@@ -1085,41 +1491,27 @@
      *  @returns void
      *  @private
      */
-    "_fnDestroy": function ()
-    {
+    "_fnDestroy": function () {
       var i, iLen;
 
-      for ( i=0, iLen=this.s.dt.aoDrawCallback.length ; i<iLen ; i++ )
-      {
-        if ( this.s.dt.aoDrawCallback[i].sName === 'ColReorder_Pre' )
-        {
-          this.s.dt.aoDrawCallback.splice( i, 1 );
+      for (i = 0, iLen = this.s.dt.aoDrawCallback.length; i < iLen; i++) {
+        if (this.s.dt.aoDrawCallback[i].sName === 'ColReorder_Pre') {
+          this.s.dt.aoDrawCallback.splice(i, 1);
           break;
         }
       }
 
-      $(this.s.dt.nTHead).find( '*' ).off( '.ColReorder' );
+      for (i = 0, iLen = ColReorder.aoInstances.length; i < iLen; i++) {
+        if (ColReorder.aoInstances[i] === this) {
+          ColReorder.aoInstances.splice(i, 1);
+          break;
+        }
+      }
 
-      $.each( this.s.dt.aoColumns, function (i, column) {
-        $(column.nTh).removeAttr('data-column-index');
-      } );
+      $(this.s.dt.nTHead).find('*').off('.ColReorder');
 
-      this.s.dt._colReorder = null;
+      this.s.dt.oInstance._oPluginColReorder = null;
       this.s = null;
-    },
-
-
-    /**
-     * Add a data attribute to the column headers, so we know the index of
-     * the row to be reordered. This allows fast detection of the index, and
-     * for this plug-in to work with FixedHeader which clones the nodes.
-     *  @private
-     */
-    "_fnSetColumnIndexes": function ()
-    {
-      $.each( this.s.dt.aoColumns, function (i, column) {
-        $(column.nTh).attr('data-column-index', i);
-      } );
     }
   };
 
@@ -1130,6 +1522,16 @@
   /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
    * Static parameters
    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+  /**
+   * Array of all ColReorder instances for later reference
+   *  @property ColReorder.aoInstances
+   *  @type     array
+   *  @default  []
+   *  @static
+   *  @private
+   */
+  ColReorder.aoInstances = [];
 
 
   /**
@@ -1148,19 +1550,19 @@
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "aiOrder": [ 4, 3, 2, 1, 0 ]
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "aiOrder": [ 4, 3, 2, 1, 0 ]
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "aiOrder": [ 4, 3, 2, 1, 0 ]
-     *      } );
+        *          "aiOrder": [ 4, 3, 2, 1, 0 ]
+        *      } );
      */
     aiOrder: null,
 
@@ -1176,19 +1578,19 @@
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "bRealtime": true
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "bRealtime": true
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "bRealtime": true
-     *      } );
+        *          "bRealtime": true
+        *      } );
      */
     bRealtime: false,
 
@@ -1201,19 +1603,19 @@
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "iFixedColumns": 1
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "iFixedColumns": 1
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "iFixedColumns": 1
-     *      } );
+        *          "iFixedColumns": 1
+        *      } );
      */
     iFixedColumns: 0,
 
@@ -1225,19 +1627,19 @@
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "iFixedColumnsRight": 1
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "iFixedColumnsRight": 1
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "iFixedColumnsRight": 1
-     *      } );
+        *          "iFixedColumnsRight": 1
+        *      } );
      */
     iFixedColumnsRight: 0,
 
@@ -1249,26 +1651,53 @@
      *  @example
      *      // Using the `oColReorder` option in the DataTables options object
      *      $('#example').dataTable( {
-     *          "sDom": 'Rlfrtip',
-     *          "oColReorder": {
-     *              "fnReorderCallback": function () {
-     *                  alert( 'Columns reordered' );
-     *              }
-     *          }
-     *      } );
+        *          "sDom": 'Rlfrtip',
+        *          "oColReorder": {
+        *              "fnReorderCallback": function () {
+        *                  alert( 'Columns reordered' );
+        *              }
+        *          }
+        *      } );
      *
      *  @example
      *      // Using `new` constructor
      *      $('#example').dataTable()
      *
      *      new $.fn.dataTable.ColReorder( '#example', {
-     *          "fnReorderCallback": function () {
-     *              alert( 'Columns reordered' );
-     *          }
-     *      } );
+        *          "fnReorderCallback": function () {
+        *              alert( 'Columns reordered' );
+        *          }
+        *      } );
      */
     fnReorderCallback: null
   };
+
+
+
+
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   * Static functions
+   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+  /**
+   * `Deprecated` Reset the column ordering for a DataTables instance
+   *  @method  ColReorder.fnReset
+   *  @param   object oTable DataTables instance to consider
+   *  @returns void
+   *  @static
+   *  @deprecated Use `ColReorder( table ).fnReset()` instead.
+   */
+  ColReorder.fnReset = function (oTable) {
+    for (var i = 0, iLen = ColReorder.aoInstances.length; i < iLen; i++) {
+      if (ColReorder.aoInstances[i].s.dt.oInstance == oTable) {
+        ColReorder.aoInstances[i].fnReset();
+      }
+    }
+  };
+
+
+
 
 
 
@@ -1278,90 +1707,56 @@
 
   /**
    * ColReorder version
-   *  @constant  version
+   *  @constant  VERSION
    *  @type      String
    *  @default   As code
    */
-  ColReorder.version = "1.1.3-dev";
+  ColReorder.VERSION = "1.1.0-dev";
+  ColReorder.prototype.VERSION = ColReorder.VERSION;
+
+
 
 
 
   /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-   * DataTables interfaces
+   * Initialisation
    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-  // Expose
-  $.fn.dataTable.ColReorder = ColReorder;
-  $.fn.DataTable.ColReorder = ColReorder;
-
-
-  // Register a new feature with DataTables
-  if ( typeof $.fn.dataTable == "function" &&
-       typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
-       $.fn.dataTableExt.fnVersionCheck('1.9.3') )
-  {
-    $.fn.dataTableExt.aoFeatures.push( {
-      "fnInit": function( settings ) {
+  /*
+   * Register a new feature with DataTables
+   */
+  if (typeof $.fn.dataTable == "function" &&
+    typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
+    $.fn.dataTableExt.fnVersionCheck('1.9.3')) {
+    $.fn.dataTableExt.aoFeatures.push({
+      "fnInit": function (settings) {
         var table = settings.oInstance;
 
-        if ( ! settings._colReorder ) {
-          var dtInit = settings.oInit;
-          var opts = dtInit.colReorder || dtInit.oColReorder || {};
+        if (table._oPluginColReorder === undefined) {
+          var opts = settings.oInit.oColReorder !== undefined ?
+            settings.oInit.oColReorder :
+          {};
 
-          new ColReorder( settings, opts );
+          table._oPluginColReorder = new ColReorder(settings, opts);
         }
         else {
-          table.oApi._fnLog( settings, 1, "ColReorder attempted to initialise twice. Ignoring second" );
+          table.oApi._fnLog(settings, 1, "ColReorder attempted to initialise twice. Ignoring second");
         }
 
         return null; /* No node for DataTables to insert */
       },
       "cFeature": "R",
       "sFeature": "ColReorder"
-    } );
+    });
   }
   else {
-    alert( "Warning: ColReorder requires DataTables 1.9.3 or greater - www.datatables.net/download");
+    alert("Warning: ColReorder requires DataTables 1.9.3 or greater - www.datatables.net/download");
   }
 
 
-  // API augmentation
-  if ( $.fn.dataTable.Api ) {
-    $.fn.dataTable.Api.register( 'colReorder.reset()', function () {
-      return this.iterator( 'table', function ( ctx ) {
-        ctx._colReorder.fnReset();
-      } );
-    } );
-
-    $.fn.dataTable.Api.register( 'colReorder.order()', function ( set ) {
-      if ( set ) {
-        return this.iterator( 'table', function ( ctx ) {
-          ctx._colReorder.fnOrder( set );
-        } );
-      }
-
-      return this.context.length ?
-        this.context[0]._colReorder.fnOrder() :
-        null;
-    } );
-  }
-
-  return ColReorder;
-  }; // /factory
+  window.ColReorder = ColReorder;
+  $.fn.dataTable.ColReorder = ColReorder;
 
 
-  // Define as an AMD module if possible
-  if ( typeof define === 'function' && define.amd ) {
-    define( ['jquery', 'datatables'], factory );
-  }
-  else if ( typeof exports === 'object' ) {
-      // Node/CommonJS
-      factory( require('jquery'), require('datatables') );
-  }
-  else if ( jQuery && !jQuery.fn.dataTable.ColReorder ) {
-    // Otherwise simply initialise as normal, stopping multiple evaluation
-    factory( jQuery, jQuery.fn.dataTable );
-  }
+})(jQuery, window, document);
 
-
-})(window, document);

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -166,13 +166,17 @@ var LocalDataTable = (function() {
 
     _enableReorderableColumns: function() {
       var self = this;
-      new $.fn.dataTable.ColReorder(this.dataTable, {
+      self._colReorder = new $.fn.dataTable.ColReorder(this.dataTable, {
         fnReorderCallback: function(fromIndex, toIndex) {
           // notify that columns have been externally rearranged
           self._columnManager.columnsSwapped(fromIndex, toIndex);
           // pass event up
           self._onColumnReorder();
-        }
+        },
+        bAddFixed: false,
+        bResizeTableWrapper: false,
+        allowHeaderDoubleClick: false,
+        allowResize: self.resizableColumns
       });
     },
 
@@ -183,11 +187,11 @@ var LocalDataTable = (function() {
     _changeColumnOrder: function(order) {
       var columnsOrig = _.clone(this.dataTable.fnSettings().aoColumns);
       if (_.isArray(order)) {
-        this.dataTable.fnSettings()._colReorder.fnOrder(order);
+        this._colReorder.fnOrder(order);
       } else if (_.has(order, 'reset') && order.reset) {
-        this.dataTable.fnSettings()._colReorder.fnReset();
+        this._colReorder.fnReset();
       } else {
-        return this.dataTable.fnSettings()._colReorder.fnOrder();
+        return this._colReorder.fnOrder();
       }
 
       // restore columnsConfig order to match the underlying order from dataTable
@@ -226,6 +230,7 @@ var LocalDataTable = (function() {
         filteringEnabled: false,
         layout : "<'row'<'col-xs-6'l><'col-xs-6'f>r>t<'row'<'col-xs-6'i><'col-xs-6'p>>",
         reorderableColumns: true,
+        resizableColumns: false,
         objectName: {
           singular: "row",
           plural: "rows"


### PR DESCRIPTION
@mileszim @albertovillalobos @Vicentecarrillo 

I looked into resize plugins for dataTables and this is the best (only?) one I could find that worked with our older version of dataTables and also is just a fork of the colReorder plugin we already use, so the changes are fairly minimal.

I first checked in the new ColReorderWithResize plugin as is: https://github.com/Invoca/backdraft/commit/4ac17c5a966f76c3b6659591299672a782fa5a04

Then I applied my fixes/tweaks on top of it that are needed to get this working for full-width grids.

Disclaimer: it is not working out of the box yet on tables that are fixed within a viewport. Some tweaks will need to be made before we can enable safely on the management grids. (That is why it's disabled by default).

I'd like to get this in and start playing with it on the reporting app (but we need to be sure this does not break the basic ColReorder functionality that is already in use in many places).

The diff isn't shown in github on `src/plugins/data_table/dataTables.colReorder.js` lame. You may want to try using reviewable.io or diffing locally.