### PR TITLE
Add support for emptyText customization for local tables

### DIFF
--- a/dist/backdraft.js
+++ b/dist/backdraft.js
@@ -1396,7 +1396,10 @@ _.extend(Plugin.factory, {
         fnCreatedRow : this._onRowCreated,
         aoColumns : this._columnManager.dataTableColumnsConfig(),
         aaSorting : this._columnManager.dataTableSortingConfig(),
-        fnDrawCallback : this._onDraw
+        fnDrawCallback : this._onDraw,
+        oLanguage: {
+          sEmptyTable: this.emptyText
+        }
       };
     },
 
@@ -1826,7 +1829,7 @@ _.extend(Plugin.factory, {
     _dataTableConfig : function() {
       var config = ServerSideDataTable.__super__._dataTableConfig.apply(this, arguments);
       // add server side related options
-      return _.extend(config, {
+      return $.extend(true, config, {
         bProcessing : true,
         bServerSide : true,
         sAjaxSource : _.result(this.collection, "url"),
@@ -1834,8 +1837,7 @@ _.extend(Plugin.factory, {
         fnServerParams : this._addServerParams,
         fnDrawCallback : this._onDraw,
         oLanguage: {
-          sProcessing: this.processingText,
-          sEmptyTable: this.emptyText
+          sProcessing: this.processingText
         }
       });
     },

--- a/spec/plugins/data_table/local.js
+++ b/spec/plugins/data_table/local.js
@@ -104,6 +104,27 @@ describe("DataTable Plugin", function() {
         });
       });
     });
+
+    describe("customization", function() {
+      beforeEach(function() {
+        app.view.dataTable.row("R", {
+          columns : [
+            { attr : "name", title : "Name" }
+          ]
+        });
+      });
+
+      it("should allow a empty text to be provided", function() {
+        app.view.dataTable("TableWithEmptyText", {
+          rowClassName : "R",
+          emptyText: "Sad, there is nothing here!"
+        });
+
+        table = new app.Views.TableWithEmptyText({ collection : collection });
+        table.render();
+        expect(table.$(".dataTables_empty").text()).toEqual("Sad, there is nothing here!");
+      });
+    });
   });
 
   describe("local data store pagination", function() {

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -316,7 +316,10 @@ var LocalDataTable = (function() {
         fnCreatedRow : this._onRowCreated,
         aoColumns : this._columnManager.dataTableColumnsConfig(),
         aaSorting : this._columnManager.dataTableSortingConfig(),
-        fnDrawCallback : this._onDraw
+        fnDrawCallback : this._onDraw,
+        oLanguage: {
+          sEmptyTable: this.emptyText
+        }
       };
     },
 

--- a/src/plugins/data_table/server_side_data_table.js
+++ b/src/plugins/data_table/server_side_data_table.js
@@ -246,7 +246,7 @@ var ServerSideDataTable = (function() {
     _dataTableConfig : function() {
       var config = ServerSideDataTable.__super__._dataTableConfig.apply(this, arguments);
       // add server side related options
-      return _.extend(config, {
+      return $.extend(true, config, {
         bProcessing : true,
         bServerSide : true,
         sAjaxSource : _.result(this.collection, "url"),
@@ -254,8 +254,7 @@ var ServerSideDataTable = (function() {
         fnServerParams : this._addServerParams,
         fnDrawCallback : this._onDraw,
         oLanguage: {
-          sProcessing: this.processingText,
-          sEmptyTable: this.emptyText
+          sProcessing: this.processingText
         }
       });
     },


### PR DESCRIPTION
@albertovillalobos just FYI, I ran into this today and realized `emptyText` did not work for local tables. Now they do =)