### PR TITLE
91 ux column resize bug: change .width to .outerWidth as it accounts …

### DIFF
--- a/dist/backdraft.js
+++ b/dist/backdraft.js
@@ -3174,24 +3174,23 @@ $.extend( $.fn.dataTableExt.oPagination, {
         this.s.mouse.startX = e.pageX;
         this.s.tableWidth = $(nTh).closest("table").width();
 
-
         // If we are at the left end, we expand the previous column
         if (this.dom.resizeCol == "left") {
           nThPrev = $(nTh).prev();
-          this.s.mouse.startWidth = $(nThPrev).width();
+          this.s.mouse.startWidth = $(nThPrev).outerWidth();
           this.s.mouse.resizeElem = $(nThPrev);
           nThNext = $(nTh).next();
-          this.s.mouse.nextStartWidth = $(nTh).width();
+          this.s.mouse.nextStartWidth = $(nTh).outerWidth();
           this.s.mouse.targetIndex = $('th', nTh.parentNode).index(nThPrev);
           this.s.mouse.fromIndex = this.s.dt.oInstance.oApi._fnVisibleToColumnIndex(this.s.dt, this.s.mouse.targetIndex);
         }
 
         // If we are at the right end of column, we expand the current column
         else {
-          this.s.mouse.startWidth = $(nTh).width();
+          this.s.mouse.startWidth = $(nTh).outerWidth();
           this.s.mouse.resizeElem = $(nTh);
           nThNext = $(nTh).next();
-          this.s.mouse.nextStartWidth = $(nThNext).width();
+          this.s.mouse.nextStartWidth = $(nThNext).outerWidth();
           this.s.mouse.targetIndex = $('th', nTh.parentNode).index(nTh);
           this.s.mouse.fromIndex = this.s.dt.oInstance.oApi._fnVisibleToColumnIndex(this.s.dt, this.s.mouse.targetIndex);
         }

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -1087,24 +1087,23 @@
         this.s.mouse.startX = e.pageX;
         this.s.tableWidth = $(nTh).closest("table").width();
 
-
         // If we are at the left end, we expand the previous column
         if (this.dom.resizeCol == "left") {
           nThPrev = $(nTh).prev();
-          this.s.mouse.startWidth = $(nThPrev).width();
+          this.s.mouse.startWidth = $(nThPrev).outerWidth();
           this.s.mouse.resizeElem = $(nThPrev);
           nThNext = $(nTh).next();
-          this.s.mouse.nextStartWidth = $(nTh).width();
+          this.s.mouse.nextStartWidth = $(nTh).outerWidth();
           this.s.mouse.targetIndex = $('th', nTh.parentNode).index(nThPrev);
           this.s.mouse.fromIndex = this.s.dt.oInstance.oApi._fnVisibleToColumnIndex(this.s.dt, this.s.mouse.targetIndex);
         }
 
         // If we are at the right end of column, we expand the current column
         else {
-          this.s.mouse.startWidth = $(nTh).width();
+          this.s.mouse.startWidth = $(nTh).outerWidth();
           this.s.mouse.resizeElem = $(nTh);
           nThNext = $(nTh).next();
-          this.s.mouse.nextStartWidth = $(nThNext).width();
+          this.s.mouse.nextStartWidth = $(nThNext).outerWidth();
           this.s.mouse.targetIndex = $('th', nTh.parentNode).index(nTh);
           this.s.mouse.fromIndex = this.s.dt.oInstance.oApi._fnVisibleToColumnIndex(this.s.dt, this.s.mouse.targetIndex);
         }


### PR DESCRIPTION
…for the whole computer width

@nburwell Hey Nick I found a bug with the resize that I just fixed.

To avoid shrinking adjacent columns when a column is being resized, we keep a "limit" by getting the starting width of the adjacent column so that it doesn't get smaller than what it is.

This was calculated with .width() and not .outerWidth(). So when x column was dragged into a smaller size, the one to it's left would shrink by roughly 10 pixels. This was caused because the limit was set to it's width without border or padding. With outerWidth() it accounts for those so that the adjacent columns don't shrink at all.

This bug only showed up if one expanded to adjacent columns and then shrunk the right column causing the left column to shrink by roughly 10 pixels (border+ padding)