### PR TITLE
WEB-2442 auto scroll table when dragging a column to reorder it and near viewport edge

### DIFF
--- a/examples_server/examples/data_table/large_table_column_reordering/browser_scroll.html
+++ b/examples_server/examples/data_table/large_table_column_reordering/browser_scroll.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en" class="bs">
+<head>
+  <meta charset="utf-8">
+  <title>Backdraft DataTable Examples</title>
+  <meta name="description" content="">
+  <meta name="author" content="">
+
+  <link rel="shortcut icon" href="#">
+  <link type="text/css" href="../../../vendor/bootstrap-3.1.1-dist/css/bootstrap.css" rel="stylesheet" />
+  <link type="text/css" href="../../../vendor/dataTables.bootstrap.css" rel="stylesheet" />
+  <link type="text/css" href="../../../vendor/dataTables.colReorder.css" rel="stylesheet" />
+
+  <style>
+    .dataTable th {
+      min-width: 500px;
+    }
+
+    tfoot td {
+      background-color: #eee;
+    }
+
+    #example-filters {
+      padding: 10px;
+      margin: 10px 0;
+      background-color: #ADD8E6;
+    }
+  </style>
+</head>
+
+<body>
+<h3 style="text-align:center" class="fixed-horizontally">Large Table with a scrollbar enabled on browser</h3>
+
+<div class="container-fluid">
+  <div id="example-filters" class="fixed-horizontally">
+    This filters area scrolls out of view
+  </div>
+
+  <div id="example-area"></div>
+
+  <p>
+    <a href="index.html">Back to Column Reorder Index</a>
+  </p>
+
+  <!-- libraries -->
+  <script type="text/javascript" src="../../../vendor/json2.js"></script>
+  <script type="text/javascript" src="../../../vendor/jquery-1.10.2.js"></script>
+  <script type="text/javascript" src="../../../vendor/underscore-1.8.3.js"></script>
+  <script type="text/javascript" src="../../../vendor/backbone-1.1.2.js"></script>
+  <script type="text/javascript" src="../../../vendor/jquery.dataTables-1.9.4.js"></script>
+  <script type="text/javascript" src="../../../dist/backdraft.js"></script>
+
+  <!-- demo -->
+  <script type="text/javascript" src="data_table.js"></script>
+  <script type="text/javascript">
+    Backdraft.app("TableExample").activate($("#example-area"));
+  </script>
+
+  </div>
+
+</body>
+</html>

--- a/examples_server/examples/data_table/large_table_column_reordering/browser_scroll_fixed.html
+++ b/examples_server/examples/data_table/large_table_column_reordering/browser_scroll_fixed.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en" class="bs">
+<head>
+  <meta charset="utf-8">
+  <title>Backdraft DataTable Examples</title>
+  <meta name="description" content="">
+  <meta name="author" content="">
+
+  <link rel="shortcut icon" href="#">
+  <link type="text/css" href="../../../vendor/bootstrap-3.1.1-dist/css/bootstrap.css" rel="stylesheet" />
+  <link type="text/css" href="../../../vendor/dataTables.bootstrap.css" rel="stylesheet" />
+  <link type="text/css" href="../../../vendor/dataTables.colReorder.css" rel="stylesheet" />
+
+  <style>
+    .dataTable th {
+      min-width: 500px;
+    }
+
+    tfoot td {
+      background-color: #eee;
+    }
+
+    #example-filters {
+      padding: 10px;
+      margin: 10px 0;
+      background-color: #ADD8E6;
+    }
+
+    .fixed-horizontally {
+      width: 100%;
+    }
+  </style>
+</head>
+
+<body>
+<h3 style="text-align:center" class="fixed-horizontally">Large Table with a scrollbar enabled on browser and fixed elements</h3>
+
+<div class="container-fluid">
+  <div id="example-filters" class="fixed-horizontally">
+    Sample filters area that should be fixed to viewport width and NOT scroll
+  </div>
+
+  <div id="example-area"></div>
+
+  <p>
+    <a href="index.html">Back to Column Reorder Index</a>
+  </p>
+
+  <!-- libraries -->
+  <script type="text/javascript" src="../../../vendor/json2.js"></script>
+  <script type="text/javascript" src="../../../vendor/jquery-1.10.2.js"></script>
+  <script type="text/javascript" src="../../../vendor/underscore-1.8.3.js"></script>
+  <script type="text/javascript" src="../../../vendor/backbone-1.1.2.js"></script>
+  <script type="text/javascript" src="../../../vendor/jquery.dataTables-1.9.4.js"></script>
+  <script type="text/javascript" src="../../../dist/backdraft.js"></script>
+
+  <!-- demo -->
+  <script type="text/javascript" src="data_table.js"></script>
+  <script type="text/javascript">
+    Backdraft.app("TableExample").activate($("#example-area"));
+  </script>
+
+  <script>
+    var body = $('body');
+    var table = $('.dataTables_wrapper .table-wrapper-with-footer');
+    var fixedElements = $('.fixed-horizontally');
+
+    function onWheel(e) {
+      if (e.originalEvent.ctrlKey) {
+        return true
+      }
+
+      var deltaX = e.originalEvent.deltaX;
+      var deltaY = e.originalEvent.deltaY;
+
+      if (deltaX !== 0) {
+        var currentLeft = body.scrollLeft();
+        body.scrollLeft(currentLeft + deltaX);
+      }
+
+      if (deltaY !== 0) {
+        var currentTop = body.scrollTop();
+        body.scrollTop(currentTop + deltaY);
+      }
+
+      return false;
+    }
+
+    function onScroll() {
+      console.log("onScroll " + window.scrollX);
+      fixedElements.css({
+        'margin-left': 0 + window.scrollX
+      });
+
+      table.css({
+        'margin-left': 0 - window.scrollX
+      });
+    }
+
+    $(window).on('scroll', onScroll);
+    body.on('wheel', onWheel);
+  </script>
+
+</body>
+</html>

--- a/examples_server/examples/data_table/large_table_column_reordering/data_table.js
+++ b/examples_server/examples/data_table/large_table_column_reordering/data_table.js
@@ -1,0 +1,125 @@
+Backdraft.app("TableExample", {
+
+  plugins : [ "DataTable"],
+
+  activate : function($el) {
+    this.mainRouter = new this.Routers.Main({ $el : $el });
+    Backbone.history.start({ });
+  }
+
+});
+
+Backdraft.app("TableExample", function(app) {
+
+  app.router("Main", {
+
+    routes : {
+      "" : "index"
+    },
+
+    index : function() {
+      var view = new app.Views.Index();
+      this.swap(view);
+    }
+
+  });
+
+});
+
+Backdraft.app("TableExample", function(app) {
+
+  app.model("Book", {
+
+  });
+
+});
+
+Backdraft.app("TableExample", function(app) {
+
+  app.collection("Books", {
+
+    model : app.Models.Book,
+
+    url : "/server_side_data?total=1"
+
+  });
+
+});
+
+
+
+Backdraft.app("TableExample", function(app) {
+
+  app.view.dataTable("BookTable", {
+
+    rowClassName : "BookRow",
+
+    layout : "<'table-wrapper-with-footer't><'row'<'col-xs-4'p><'col-xs-4'r><'col-xs-4'i>>",
+
+    serverSide : true,
+
+    isNontotalsColumn: function(col) {
+      return col.id !== "income";
+    },
+
+  });
+
+});
+
+Backdraft.app("TableExample", function(app) {
+
+  app.view.dataTable.row("BookRow", {
+
+    columns : [
+      { bulk : true },
+      { attr : "name", title : "Name" },
+      { attr : "address", title : "address" },
+      { attr : "income", title : "Yearly income"},
+      { title : "Random 1" },
+      { title : "Random 2" },
+      { title : "Random 3" },
+      { title : "Random 4" }
+    ],
+
+    renderers : {
+      "random-1" : function(node, config) {
+        node.text(Math.random());
+      },
+      "random-2" : function(node, config) {
+        node.text(Math.random());
+      },
+      "random-3" : function(node, config) {
+        node.text(Math.random());
+      },
+      "random-4" : function(node, config) {
+        node.text(Math.random());
+      },
+      "name" : function(node, config) {
+        node.text("name: " + this.model.get(config.attr));
+      },
+      "address" : function(node, config) {
+        node.text("addr: " + this.model.get(config.attr));
+      },
+      "income" : function(node, config) {
+        node.text("$"+this.model.get(config.attr));
+      },
+    }
+
+  });
+
+});
+
+Backdraft.app("TableExample", function(app) {
+
+  app.view("Index", {
+
+    render : function() {
+      var collection  = new app.Collections.Books();
+      this.child('table', new app.Views.BookTable({ collection : collection }));
+      this.$el.html(this.child('table').render().$el);
+      return this;
+    }
+
+  });
+
+});

--- a/examples_server/examples/data_table/large_table_column_reordering/index.html
+++ b/examples_server/examples/data_table/large_table_column_reordering/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en" class="bs">
+  <head>
+    <meta charset="utf-8">
+    <title>Backdraft DataTable Examples</title>
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <link rel="shortcut icon" href="#">
+    <link type="text/css" href="../../../vendor/bootstrap-3.1.1-dist/css/bootstrap.css" rel="stylesheet" />
+
+      <style>
+        .container a {
+          display: block;
+          padding: 10px;
+          margin: 20px;
+          max-width: 500px;
+          border: 1px solid #ddd;
+          border-radius: 5px;
+        }
+
+        .container a:hover {
+          background-color: #eee;
+        }
+      </style>
+  </head>
+
+  <body>
+    <h3 style="text-align:center">Large Tables - handling scroll and column re-ordering</h3>
+
+    <div class="container">
+
+      <a href="browser_scroll.html">Browser Scroll - traditional</a>
+
+      <a href="browser_scroll_fixed.html">Browser Scroll - fixed elements</a>
+
+      <a href="inner_scroll.html">Table with Inner Scroll</a>
+
+    </div>
+
+  </body>
+</html>

--- a/examples_server/examples/data_table/large_table_column_reordering/inner_scroll.html
+++ b/examples_server/examples/data_table/large_table_column_reordering/inner_scroll.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en" class="bs">
+<head>
+  <meta charset="utf-8">
+  <title>Backdraft DataTable Examples</title>
+  <meta name="description" content="">
+  <meta name="author" content="">
+
+  <link rel="shortcut icon" href="#">
+  <link type="text/css" href="../../../vendor/bootstrap-3.1.1-dist/css/bootstrap.css" rel="stylesheet" />
+  <link type="text/css" href="../../../vendor/dataTables.bootstrap.css" rel="stylesheet" />
+  <link type="text/css" href="../../../vendor/dataTables.colReorder.css" rel="stylesheet" />
+
+  <style>
+    .dataTable th {
+      min-width: 600px;
+    }
+
+    tfoot td {
+      background-color: #eee;
+    }
+
+    .table-wrapper-with-footer {
+      overflow-x: auto;
+    }
+  </style>
+</head>
+
+<body>
+<h3 style="text-align:center">Large Table with a scrollbar enabled on table</h3>
+
+<div class="container-fluid">
+  <div id="example-area"></div>
+
+  <p>
+    <a href="index.html">Back to Column Reorder Index</a>
+  </p>
+
+  <!-- libraries -->
+  <script type="text/javascript" src="../../../vendor/json2.js"></script>
+  <script type="text/javascript" src="../../../vendor/jquery-1.10.2.js"></script>
+  <script type="text/javascript" src="../../../vendor/underscore-1.8.3.js"></script>
+  <script type="text/javascript" src="../../../vendor/backbone-1.1.2.js"></script>
+  <script type="text/javascript" src="../../../vendor/jquery.dataTables-1.9.4.js"></script>
+  <script type="text/javascript" src="../../../dist/backdraft.js"></script>
+
+  <!-- demo -->
+  <script type="text/javascript" src="data_table.js"></script>
+  <script type="text/javascript">
+    Backdraft.app("TableExample").activate($("#example-area"));
+  </script>
+
+</body>
+</html>

--- a/spec/dom_visibility_spec.js
+++ b/spec/dom_visibility_spec.js
@@ -1,0 +1,159 @@
+describe("Backdraft.Utils.DomVisibility", function() {
+  var el, dummyDiv, previousBodyMargin;
+
+  beforeEach(function() {
+    el = $('<div>');
+    dummyDiv = $('<div>');
+    $('body').append(el);
+    $('body').append(dummyDiv);
+    previousBodyMargin = $('body').css('margin');
+    $('body').css({ margin: 0 });
+  });
+
+  afterEach(function() {
+    el.remove();
+    dummyDiv.remove();
+    $('body').css({ margin: previousBodyMargin });
+    $(window).scrollLeft(0);
+  });
+
+  it("should define a namespace for helper methods", function() {
+    expect(Backdraft.Utils.DomVisibility).toBeDefined();
+  });
+
+  describe("leftEdgeInView", function() {
+    var domViz;
+
+    beforeEach(function() {
+      el.css({ width: 9000, height: 50 });
+      domViz = new Backdraft.Utils.DomVisibility(el);
+    });
+
+    it("should handle when not scrolled horizontally and table at edge", function() {
+      expect($(window).scrollLeft()).toEqual(0);
+      expect(el.offset().left).toEqual(0);
+      expect(domViz.leftEdgeInView()).toEqual(true);
+    });
+
+    it("should handle when scrolled horizontally and table at edge", function() {
+      expect(el.offset().left).toEqual(0);
+      $(window).scrollLeft(1);
+
+      expect(domViz.leftEdgeInView()).toEqual(false);
+    });
+
+    it("should handle when scrolled horizontally and table not at edge", function() {
+      el.css('margin-left', 50);
+      expect(el.offset().left).toEqual(50);
+
+      $(window).scrollLeft(44);
+      expect(domViz.leftEdgeInView()).toEqual(true, "Scrolled to 44");
+
+      $(window).scrollLeft(51);
+      expect(domViz.leftEdgeInView()).toEqual(false, "Scrolled to 51");
+    });
+  });
+
+  describe("rightEdgeInView", function() {
+    var domViz;
+
+    beforeEach(function() {
+      el.css({ width: 9000, height: 50 });
+      domViz = new Backdraft.Utils.DomVisibility(el);
+    });
+
+    it("should handle when not scrolled horizontally and table off edge", function() {
+      expect($(window).scrollLeft()).toEqual(0);
+      expect(el.offset().left).toEqual(0);
+      expect(domViz.rightEdgeInView()).toEqual(false);
+    });
+
+    it("should handle when scrolled horizontally and table at edge", function() {
+      expect(el.offset().left).toEqual(0);
+
+      $(window).scrollLeft(el.width() - $('body').outerWidth());
+
+      expect(domViz.rightEdgeInView()).toEqual(true);
+    });
+
+    it("should handle when scrolled horizontally and table not at edge", function() {
+      dummyDiv.css({ width: 2000, height: 10 });
+      el.css({ marginLeft: 50, width: 400 });
+      expect(el.offset().left).toEqual(50);
+
+      $(window).scrollLeft(44);
+      expect(domViz.rightEdgeInView()).toEqual(false, "Scrolled to 44");
+
+      $(window).scrollLeft(51);
+      expect(domViz.rightEdgeInView()).toEqual(true, "Scrolled to 51");
+    });
+  });
+
+  describe("absolutePointAtViewportEdge", function() {
+    beforeEach(function() {
+      dummyDiv.css({ width: 1000, height: 700 });
+    });
+
+    describe("left", function() {
+      it("should handle when a point is close to edge of viewport - not scrolled", function() {
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 0, 1)).toEqual(true);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 0, 50)).toEqual(true);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 1, 1)).toEqual(true);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 50, 50)).toEqual(true);
+
+        // outside the "buffer"
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 2, 1)).toEqual(false);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 100, 50)).toEqual(false);
+      });
+
+      it("should handle when a point is close to edge of viewport - scrolled", function() {
+        $(window).scrollLeft(60);
+
+        // anything past the edge is considered at the edge
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 0, 1)).toEqual(true);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 0, 50)).toEqual(true);
+
+        // factoring in the scroll, still within the buffer
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 61, 1)).toEqual(true);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 80, 50)).toEqual(true);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 110, 50)).toEqual(true);
+
+        // outside the "buffer"
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 62, 1)).toEqual(false);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('left', 111, 50)).toEqual(false);
+      });
+    });
+
+    describe("right", function() {
+      it("should handle when a point is close to edge of viewport - not scrolled", function() {
+        expect($('body').width()).toEqual(400, "width of viewport");
+
+        // past edge is considered at the edge
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('right', 450, 1)).toEqual(true);
+
+        // at or within the bugger
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('right', 400, 1)).toEqual(true);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('right', 350, 50)).toEqual(true);
+
+        // outside the "buffer"
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('right', 399, 0)).toEqual(false);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('right', 349, 50)).toEqual(false);
+      });
+
+      it("should handle when a point is close to edge of viewport - scrolled", function() {
+        expect($('body').width()).toEqual(400, "width of viewport");
+        $(window).scrollLeft(500);
+
+        // anything past the edge is considered at the edge
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('right', 1000, 1)).toEqual(true);
+
+        // factoring in the scroll, still within the buffer
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('right', 900, 1)).toEqual(true);
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('right', 800, 100)).toEqual(true);
+
+        // outside the "buffer"
+        expect(Backdraft.Utils.Coordinates.absolutePointAtViewportEdge('right', 800, 50)).toEqual(false);
+      });
+    });
+  });
+});

--- a/spec/plugins/data_table/general.js
+++ b/spec/plugins/data_table/general.js
@@ -867,7 +867,7 @@ describe("DataTable Plugin", function() {
           stubDragMode(table);
           triggerMouseMoveEvent(table, { mouseX: $('body').outerWidth() - 50 });
 
-          expect($('body').scrollLeft()).toEqual(10, "After the move event");
+          expect($('body').scrollLeft()).toEqual(15, "After the move event");
         });
 
         it("should not scroll body right if dragging column and mouse is beyond the edge buffer", function() {
@@ -910,7 +910,7 @@ describe("DataTable Plugin", function() {
           stubDragMode(table);
           triggerMouseMoveEvent(table, { mouseX: 50 });
 
-          expect($('body').scrollLeft()).toEqual(190, "After the move event");
+          expect($('body').scrollLeft()).toEqual(185, "After the move event");
         });
 
         it("should not scroll body left if dragging column and mouse is at the left edge and table is all in view", function() {
@@ -942,7 +942,7 @@ describe("DataTable Plugin", function() {
           triggerMouseMoveEvent(table, { mouseX: $('body').outerWidth() - 50 });
 
           expect($('body').scrollLeft()).toEqual(0, "Don't move the window scroll");
-          expect(wrapper.scrollLeft()).toEqual(10, "Should move the table wrapper scroll");
+          expect(wrapper.scrollLeft()).toEqual(15, "Should move the table wrapper scroll");
         });
 
         it("should not scroll table right if dragging column and mouse is at the right edge and but table is all in view", function() {
@@ -980,7 +980,7 @@ describe("DataTable Plugin", function() {
           triggerMouseMoveEvent(table, { mouseX: 50 });
 
           expect($('body').scrollLeft()).toEqual(0, "Don't move the window scroll");
-          expect(wrapper.scrollLeft()).toEqual(originalScroll - 10, "Should move the table wrapper scroll");
+          expect(wrapper.scrollLeft()).toEqual(originalScroll - 15, "Should move the table wrapper scroll");
         });
       });
     });

--- a/spec/plugins/data_table/local.js
+++ b/spec/plugins/data_table/local.js
@@ -284,7 +284,7 @@ describe("DataTable Plugin", function() {
         table.page("next");
       });
 
-      it("should check the header bulk checkbox when a page transitions and the next page has all rows already selected", function() {
+      it("should check the header bulk checkbox when a page transitions and the next page has all rows already selected", function(done) {
         table = new app.Views.T({ collection : collection });
         table.render();
         table.selectAllVisible(true);
@@ -294,10 +294,12 @@ describe("DataTable Plugin", function() {
         // we need to test this using an async strategy because the checkbox is toggled async as well
         table.dataTable.on("page", function() {
           _.defer(function() {
-            table.page("previous");
             expect(table.$("th.bulk :checkbox").prop("checked")).toEqual(true);
+            done();
           });
         });
+
+        table.page("previous");
       });
 
       describe("selectedIds", function() {

--- a/spec/plugins/data_table/server_side.js
+++ b/spec/plugins/data_table/server_side.js
@@ -849,7 +849,7 @@ describe("DataTable Plugin", function() {
     function getColumnConfigByCSS(element) {
       var id = Backdraft.Utils.extractColumnCSSClass(element.className).replace("column-","");
       return cg.columnConfigById.attributes[id];
-    };
+    }
 
     function clearFilters() {
       table.dataTable.find("thead th").not(".bulk").each(function (index) {
@@ -875,7 +875,7 @@ describe("DataTable Plugin", function() {
           }
         }
       });
-    };
+    }
 
     function populateFilters() {
       table.dataTable.find("thead th").not(".bulk").each(function (index) {
@@ -1210,6 +1210,7 @@ describe("DataTable Plugin", function() {
         if (wrapper) {
           var col = getColumnConfigByCSS(this);
           if (col && col.filter) {
+            // todo: the below are not asserting anything! (and currently not returning 'true')
             expect($(".filterMenu", this).is(":hidden"));
             $("span", this).trigger("click");
             expect($(".filterMenu", this).is(":visible"));
@@ -1218,6 +1219,8 @@ describe("DataTable Plugin", function() {
           }
         }
       });
+
+      expect(true).toBe(true, "Fix the above expect statements to be valid tests");
     });
 
     it("should close the activeFilterMenu when the user clicks out of it", function() {
@@ -1248,6 +1251,8 @@ describe("DataTable Plugin", function() {
               lastFilterMenu = currentFilterMenu;
             }
             currentFilterMenu = $(".filterMenu", this);
+
+            // todo: the below are not asserting anything! (and currently not returning 'true')
             expect(currentFilterMenu.is(":hidden"));
             $("span", this).trigger("click");
             expect(currentFilterMenu.is(":visible"));
@@ -1257,6 +1262,8 @@ describe("DataTable Plugin", function() {
           }
         }
       });
+
+      expect(true).toBe(true, "Fix the above expect statements to be valid tests");
     });
 
     it("should clear the filters when the clear button is clicked", function() {

--- a/src/backdraft.js
+++ b/src/backdraft.js
@@ -11,6 +11,7 @@
   }
 
   {%= inline("src/utils/class.js") %}
+  {%= inline("src/utils/dom_visibility.js") %}
   {%= inline("src/utils/css.js") %}
   {%= inline("src/utils/logging.js") %}
 

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -433,7 +433,7 @@
        * @type     integer
        * @default  10
        */
-      "autoScrollIncrementSize": 10,
+      "autoScrollIncrementSize": 15,
 
       /**
        * Resize the table when columns are resized

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -1294,16 +1294,16 @@
 
         /* check if table should scroll */
         if (this.s.autoScrollTargetWidth > 0) {
-          var tableWrapper = $(this.s.dt.nTableWrapper).find('.table-wrapper-with-footer');
+          var scrollableContainer;
           var startingScrollOffset;
           var scrollDelta;
 
           var moreToRight = false, moreToLeft = false;
-          if (tableWrapper.css('overflow-x') === 'auto') {
-            scrollableContainer = tableWrapper;
-            startingScrollOffset = tableWrapper.scrollLeft();
-            moreToRight = tableWrapper.scrollLeft() < $(this.s.dt.nTable).width() - tableWrapper.width();
-            moreToLeft = tableWrapper.scrollLeft() > 0;
+          if ($(this.s.dt.nTable).parent().css('overflow-x') === 'auto') {
+            scrollableContainer = $(this.s.dt.nTable).parent();
+            startingScrollOffset = scrollableContainer.scrollLeft();
+            moreToRight = scrollableContainer.scrollLeft() < $(this.s.dt.nTable).width() - scrollableContainer.width();
+            moreToLeft = scrollableContainer.scrollLeft() > 0;
           } else {
             scrollableContainer = $(window);
             var visibilityChecker = new Backdraft.Utils.DomVisibility(this.s.dt.nTable);

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -418,6 +418,24 @@
       "minResizeWidth": 10,
 
       /**
+       * The width from edge of browser where table will start autoscrolling if mouse is dragging and enters the region
+       * If set to 0, no auto scrolling will be done
+       * @property autoScrollTargetWidth
+       * @type     integer
+       * @default  100
+       */
+      "autoScrollTargetWidth": 100,
+
+      /**
+       * The pixel amount to autoscroll during column reorder drag events (per received mouse move event)
+       * Higher numbers mean a faster autoscroll, not recommended to go below 5
+       * @property autoScrollIncrementSize
+       * @type     integer
+       * @default  10
+       */
+      "autoScrollIncrementSize": 10,
+
+      /**
        * Resize the table when columns are resized
        * @property bResizeTable
        * @type     boolean
@@ -1272,6 +1290,53 @@
             return;
           }
           this._fnCreateDragNode();
+        }
+
+        /* check if table should scroll */
+        if (this.s.autoScrollTargetWidth > 0) {
+          var tableWrapper = $(this.s.dt.nTableWrapper).find('.table-wrapper-with-footer');
+          var startingScrollOffset;
+          var scrollDelta;
+
+          var moreToRight = false, moreToLeft = false;
+          if (tableWrapper.css('overflow-x') === 'auto') {
+            scrollableContainer = tableWrapper;
+            startingScrollOffset = tableWrapper.scrollLeft();
+            moreToRight = tableWrapper.scrollLeft() < $(this.s.dt.nTable).width() - tableWrapper.width();
+            moreToLeft = tableWrapper.scrollLeft() > 0;
+          } else {
+            scrollableContainer = $(window);
+            var visibilityChecker = new Backdraft.Utils.DomVisibility(this.s.dt.nTable);
+            startingScrollOffset = visibilityChecker.windowOffset();
+            moreToRight = !visibilityChecker.rightEdgeInView();
+            moreToLeft = !visibilityChecker.leftEdgeInView();
+          }
+
+          if (
+            Backdraft.Utils.Coordinates.absolutePointAtViewportEdge(
+              'right',
+              e.pageX,
+              this.s.autoScrollTargetWidth
+            ) && moreToRight) {
+
+            scrollDelta = this.s.autoScrollIncrementSize;
+          } else if (
+            Backdraft.Utils.Coordinates.absolutePointAtViewportEdge(
+              'left',
+              e.pageX,
+              this.s.autoScrollTargetWidth
+            ) && moreToLeft) {
+
+            scrollDelta = 0 - this.s.autoScrollIncrementSize;
+          }
+
+          if (scrollDelta) {
+            scrollableContainer.scrollLeft(startingScrollOffset + scrollDelta);
+          }
+
+          // scrollLeft fires an event that isn't processed til after this mouseMove event is finished
+          //  so we're always resetting the dropzone targets cache so that later mouseMove's "fix" up the dropzones
+          this._fnRegions();
         }
 
         /* Position the element - we respect where in the element the click occured */

--- a/src/utils/dom_visibility.js
+++ b/src/utils/dom_visibility.js
@@ -1,0 +1,37 @@
+Backdraft.Utils.DomVisibility = Backdraft.Utils.Class.extend({
+  initialize: function(el) {
+    this.el = $(el);
+  },
+
+  leftEdgeInView: function() {
+    var x = this.el.offset().left;
+
+    return this.windowOffset() <= x;
+  },
+
+  rightEdgeInView: function() {
+    var x = this.el.offset().left;
+    var width = this.el.outerWidth();
+
+    return (x + width) <= ($('body').outerWidth() + this.windowOffset());
+  },
+  
+  windowOffset: function() {
+    return $(window).scrollLeft();
+  }
+});
+
+Backdraft.Utils.Coordinates = {
+  absolutePointAtViewportEdge: function(edge, x, buffer) {
+    switch(edge) {
+      case 'left':
+        return x - $(window).scrollLeft() <= buffer;
+
+      case 'right':
+        return x - $(window).scrollLeft() >= $('body').outerWidth() - buffer;
+
+      default:
+        throw new Error("unsupported edge value: " + edge);
+    }
+  }
+};

--- a/src/utils/dom_visibility.js
+++ b/src/utils/dom_visibility.js
@@ -15,9 +15,9 @@ Backdraft.Utils.DomVisibility = Backdraft.Utils.Class.extend({
 
     return (x + width) <= ($('body').outerWidth() + this.windowOffset());
   },
-  
+
   windowOffset: function() {
-    return $(window).scrollLeft();
+    return $('body').scrollLeft();
   }
 });
 
@@ -25,10 +25,10 @@ Backdraft.Utils.Coordinates = {
   absolutePointAtViewportEdge: function(edge, x, buffer) {
     switch(edge) {
       case 'left':
-        return x - $(window).scrollLeft() <= buffer;
+        return x - $('body').scrollLeft() <= buffer;
 
       case 'right':
-        return x - $(window).scrollLeft() >= $('body').outerWidth() - buffer;
+        return x - $('body').scrollLeft() >= $('body').outerWidth() - buffer;
 
       default:
         throw new Error("unsupported edge value: " + edge);


### PR DESCRIPTION
@garvank here is my PR for auto scroll of table when moving columns

I am going to see if I can clean up the logic as I put in support for both types of tables (overflow auto on the wrapper), versus a more traditional table that spills out past the viewport.  Supporting both made it get a bit messier, plus is coupled right now to a wrapper class we use by convention which I don't like.
