### PR TITLE
1702/m/web 2299 fixed table header

### DIFF
--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -992,33 +992,15 @@
                top: navbarHeight,
                width: tableWrapper.width(),
                overflow: 'hidden',
-               'border-bottom': '1px solid #eaeaea',
                left: tableLeftOffset,
                'z-index': 1
-             });
+             }).addClass('stuck');
 
              matchHeaderWidths();
              handleTableScroll();
 
              table.css({
                'margin-top': thead.height()
-             });
-
-             theadTh.each(function (i) {
-               var minWidth = parseInt($(this).css('min-width').replace('px', '')) + 5;
-               var newWidth = (headerWidths[i] > minWidth) ? headerWidths[i] : minWidth;
-
-               $(this).css({
-                 width: newWidth
-               });
-             });
-
-             tbodyTr.each(function (i) {
-               $(this).children('td').each(function(i) {
-                 $(this).css({
-                   width: headerWidths[i]
-                 });
-               });
              });
 
              stuck = true;
@@ -1028,9 +1010,8 @@
              thead.css({
                position: 'inherit',
                top: 'inherit',
-               left: 'initial',
-               'border-bottom': 'inherit'
-             });
+               left: 'initial'
+             }).removeClass('stuck');
 
              table.css({
                'margin-top': 'inherit'
@@ -1170,8 +1151,8 @@
       var thead = $(nTh).closest('thead');
       // listen to mousemove event for resize
       if (this.s.allowResize) {
-        //$(nTh).bind('mousemove.ColReorder', function (e) {
-        thead.bind('mousemove.ColReorder', function (e) {
+        $(nTh).bind('mousemove.ColReorder', function (e) {
+        //thead.bind('mousemove.ColReorder', function (e) {
           var nTable = that.s.dt.nTable;
           if (that.dom.drag === null && that.dom.resize === null) {
             /* Store information about the mouse position */

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -708,6 +708,7 @@
       /* Sticky thead option */
       if (this.s.init.iStickyTableHeader) {
         this.s.iStickyTableHeader = this.s.init.iStickyTableHeader;
+        this._fnSetupStickyTableHeader.call(this, this.s.iStickyTableHeader);
       }
 
       /* Allow reorder */
@@ -953,7 +954,6 @@
        function start() {
          var th, minWidth, minX;
          var $window           = $(window);
-         var navbarHeight      = offsetTop;
          var tableWrapper      = $(this.s.dt.nTableWrapper.children[0]);
          var table             = $(this.s.dt.nTable);
          var thead             = $(this.s.dt.nTHead);
@@ -961,7 +961,7 @@
          var tbody             = $(this.s.dt.nTBody);
          var tbodyTr           = tbody.children('tr');
          var theadTh           = thead.children('tr').children('th');
-         var tableBorderOffset = tableWrapper.css('border-left') ? parseInt(tableWrapper.css('border-left').match('.*px')[0].replace('px', '')) : 0;
+         var tableBorderOffset = getHorizontalBorderOffset(tableWrapper);
          var tableLeftOffset   = tableWrapper.offset() ? tableWrapper.offset().left + tableBorderOffset : 0;
          var stuck             = false;
          var headerWidths      = $.map(this.s.dt.aoHeader[0], function (th) {
@@ -982,14 +982,14 @@
          }
 
          function handleWindowScroll() {
-           if (!stuck && $window.scrollTop() > theadTop - navbarHeight) {
+           if (!stuck && $window.scrollTop() > theadTop - offsetTop) {
              toggleListeners('on');
              theadTh  = thead.children('tr').children('th');
              theadTop = tableWrapper.offset().top;
 
              thead.css({
                position: 'fixed',
-               top: navbarHeight,
+               top: offsetTop,
                width: tableWrapper.width(),
                overflow: 'hidden',
                left: tableLeftOffset,
@@ -1004,7 +1004,7 @@
              });
 
              stuck = true;
-           } else if (stuck && $window.scrollTop() < theadTop - navbarHeight) {
+           } else if (stuck && $window.scrollTop() < theadTop - offsetTop) {
              toggleListeners('off');
 
              thead.css({
@@ -1089,6 +1089,19 @@
                });
              });
            });
+         }
+
+         function getHorizontalBorderOffset($el) {
+           var horizontalBorders = ['border', 'border-left'], border = 0;
+           for (var i = 0; i < horizontalBorders.length; i++) {
+             var match;
+             if ((match = $el.css(horizontalBorders[i]).match('.*px')) && match.length > 0) {
+               border = parseInt(match[0].replace('px', ''));
+               break;
+             }
+           }
+
+           return border;
          }
        }
      },

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -58,6 +58,7 @@ var LocalDataTable = (function() {
       this._enableRowHighlight();
       this.paginate && this._initPaginationHandling();
       this._triggerChangeSelection();
+      this._colReorder && this._colReorder._fnSetupStickyTableHeader.call(this._colReorder, this._colReorder.s.iStickyTableHeader);
       this.trigger("render");
       return this;
     },
@@ -241,6 +242,7 @@ var LocalDataTable = (function() {
         bResizeTableWrapper: false,
         allowHeaderDoubleClick: false,
         allowResize: self.resizableColumns,
+        iStickyTableHeader: self.stickyTableHeader,
         // iFixedColumns configures how many columns should be unmovable starting from left
         // if the first column is the bulk column we make it unmovable
         iFixedColumns: this.$el.find(this.BULK_COLUMN_HEADER_CHECKBOX_SELECTOR).length

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -58,7 +58,6 @@ var LocalDataTable = (function() {
       this._enableRowHighlight();
       this.paginate && this._initPaginationHandling();
       this._triggerChangeSelection();
-      this._colReorder && this._colReorder._fnSetupStickyTableHeader.call(this._colReorder, this._colReorder.s.iStickyTableHeader);
       this.trigger("render");
       return this;
     },


### PR DESCRIPTION
@nburwell here is the draft where if you scroll too far left the sizes bug out.
You can see my best attempt in `handleMouseMove` to fix the behavior but it isn't quite perfect.

I have more context on the relevant mousemove functions in `ColReorder` that I think might be involved if needed.