### PR TITLE
1705/m/web 2443.web 2960 truncate columns and persist widths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 node_modules
 dist/
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backdraft-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Plugin-based UI application framework built on top of and extending Backbone to create single page apps",
   "main": "src/app.js",
   "files": [

--- a/spec/plugins/data_table/general.js
+++ b/spec/plugins/data_table/general.js
@@ -1252,7 +1252,7 @@ describe("DataTable Plugin", function() {
         stubResizeMode(table);
         triggerMouseMoveEvent(table, { mouseX: -3000 });
         var interceptor = $('thead th .DataTables_sort_interceptor');
-        expect(parseInt(interceptor.css('max-width'))).toEqual(table._colReorder.s.minResizeWidth, "respect min resize width");
+        expect(parseInt(interceptor.css('max-width'))).toEqual(table._colReorder.s.minResizeWidth + 1, "respect min resize width");
       });
     });
   });

--- a/spec/plugins/data_table/local.js
+++ b/spec/plugins/data_table/local.js
@@ -613,5 +613,35 @@ describe("DataTable Plugin", function() {
         expect(table.$(".header-groups-row").length).toEqual(0);
       });
     });
-  })
+  });
+
+  describe("_columnElements", function() {
+    beforeEach(function() {
+      app.view.dataTable.row("R", {
+        columns : [
+          { bulk : true },
+          { attr : "name", title : "Name" }
+        ]
+      });
+      app.view.dataTable("T", {
+        rowClassName : "R"
+      });
+
+      table = new app.Views.T({ collection : collection });
+      table.render();
+    });
+
+    afterEach(function() {
+      table.close();
+    });
+
+    it("should provide all of the column header elements", function() {
+      var expectedHeaders = table.$('table').find('thead tr th');
+      expect(expectedHeaders).toEqual(table._columnElements());
+    });
+
+    it("should allow custom selectors", function() {
+      expect(table.$('table').find('thead tr th:not(.bulk)')).toEqual(table._columnElements(":not(.bulk)"));
+    });
+  });
 });

--- a/spec/plugins/data_table/local.js
+++ b/spec/plugins/data_table/local.js
@@ -615,7 +615,7 @@ describe("DataTable Plugin", function() {
     });
   });
 
-  describe("_columnElements", function() {
+  describe("columnElements", function() {
     beforeEach(function() {
       app.view.dataTable.row("R", {
         columns : [
@@ -637,11 +637,11 @@ describe("DataTable Plugin", function() {
 
     it("should provide all of the column header elements", function() {
       var expectedHeaders = table.$('table').find('thead tr th');
-      expect(expectedHeaders).toEqual(table._columnElements());
+      expect(expectedHeaders).toEqual(table.columnElements());
     });
 
     it("should allow custom selectors", function() {
-      expect(table.$('table').find('thead tr th:not(.bulk)')).toEqual(table._columnElements(":not(.bulk)"));
+      expect(table.$('table').find('thead tr th:not(.bulk)')).toEqual(table.columnElements(":not(.bulk)"));
     });
   });
 });

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -530,7 +530,7 @@
     var tableElement = $(this.s.dt.nTable);
 
     if (this.s.bResizeTableWrapper) {
-      tableElement.width(tableElement.width());
+      $(this.s.dt.nTableWrapper).width(tableElement.width());
 
       // make sure the headers are the same width as the rest of table
       oDTSettings.aoDrawCallback.push({

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -436,6 +436,14 @@
       "autoScrollIncrementSize": 15,
 
       /**
+       * Truncate column headers on resize
+       * @property bTruncateHeaders
+       * @type     boolean
+       * @default  true
+       */
+      "bTruncateHeaders": true,
+
+      /**
        * Resize the table when columns are resized
        * @property bResizeTable
        * @type     boolean
@@ -445,7 +453,7 @@
 
       /**
        * Resize the table when columns are resized
-       * @property bResizeTable
+       * @property bResizeTableWrapper
        * @type     boolean
        * @default  false
        */
@@ -1264,6 +1272,13 @@
               $($(tableScroller)[0].childNodes[0]).css('min-width',newTableWidth);
             }
           }
+        }
+
+        debugger;
+        if (this.s.bTruncateHeaders) {
+          var sortInterceptor = $(nTh).find("div.DataTables_sort_interceptor");
+          var newInterceptorWidth = newWidth - ($(nTh).innerWidth() - $(nTh).width());
+          sortInterceptor.css({ 'max-width': newInterceptorWidth });
         }
 
         if (this.s.bResizeTable) {

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -527,8 +527,10 @@
     ColReorder.aoInstances.push(this);
 
 
+    var tableElement = $(this.s.dt.nTable)
+
     if (this.s.bResizeTableWrapper) {
-      $(this.s.dt.nTableWrapper).width($(this.s.dt.nTable).width());
+      tableElement.width(tableElement.width());
 
       // make sure the headers are the same width as the rest of table
       oDTSettings.aoDrawCallback.push({
@@ -542,9 +544,18 @@
     // fix the width and add table layout fixed.
     if (this.s.bAddFixed) {
       // Set the table to minimum size so that it doesn't stretch too far
-      $(this.s.dt.nTable).width("10px");
-      $(this.s.dt.nTable).width($(this.s.dt.nTable).width()).css('table-layout','fixed');
+      tableElement.width("10px");
+      tableElement.width(tableElement.width()).css('table-layout','fixed');
     }
+
+    if (this.s.allowResize && this.s.bTruncateHeaders) {
+      tableElement.find("thead th div.DataTables_sort_interceptor").css({
+        "text-overflow": "ellipsis",
+        "white-space":   "nowrap",
+        "overflow":      "hidden"
+      });
+    }
+
     return this;
   };
 
@@ -741,6 +752,10 @@
 
       if (typeof this.s.init.bResizeTableWrapper != 'undefined') {
         this.s.bResizeTableWrapper = this.s.init.bResizeTableWrapper;
+      }
+
+      if (typeof this.s.init.bTruncateHeaders != 'undefined') {
+        this.s.bTruncateHeaders = this.s.init.bTruncateHeaders;
       }
 
       if (typeof this.s.init.bAddFixed != 'undefined') {
@@ -1106,6 +1121,7 @@
      *  @private
      */
     "_fnMouseDown": function (e, nTh, i) {
+      // TODO: ajacobs check if this is allowing us to resize bulk actions
       var that = this;
       var target, offset, idx, nThNext, nThPrev;
       /* are we resizing a column ? */
@@ -1274,10 +1290,12 @@
           }
         }
 
-        debugger;
         if (this.s.bTruncateHeaders) {
           var sortInterceptor = $(nTh).find("div.DataTables_sort_interceptor");
           var newInterceptorWidth = newWidth - ($(nTh).innerWidth() - $(nTh).width());
+          if (newInterceptorWidth < this.s.minResizeWidth) {
+            newInterceptorWidth = this.s.minResizeWidth;
+          }
           sortInterceptor.css({ 'max-width': newInterceptorWidth });
         }
 

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -71,7 +71,7 @@
   function fnDomSwitch(nParent, iFrom, iTo) {
     var anTags = [];
     for (var i = 0, iLen = nParent.childNodes.length; i < iLen; i++) {
-      if (nParent.childNodes[i].nodeType == 1) {
+      if (nParent.childNodes[i].nodeType === 1) {
         anTags.push(nParent.childNodes[i]);
       }
     }
@@ -108,7 +108,7 @@
     var i, iLen, j, jLen, iCols = oSettings.aoColumns.length, nTrs, oCol;
 
     /* Sanity check in the input */
-    if (iFrom == iTo) {
+    if (iFrom === iTo) {
       /* Pointless reorder */
       return;
     }
@@ -243,7 +243,7 @@
       "aiInvertMapping": aiInvertMapping
     }]);
 
-    if (typeof oSettings.oInstance._oPluginFixedHeader != 'undefined') {
+    if (typeof oSettings.oInstance._oPluginFixedHeader !== 'undefined') {
       oSettings.oInstance._oPluginFixedHeader.fnUpdate();
     }
   };
@@ -292,7 +292,7 @@
     if (this instanceof ColReorder === false) {
       // Get a ColReorder instance - effectively a static method
       for (var i = 0, iLen = ColReorder.aoInstances.length; i < iLen; i++) {
-        if (ColReorder.aoInstances[i].s.dt == oDTSettings) {
+        if (ColReorder.aoInstances[i].s.dt === oDTSettings) {
           return ColReorder.aoInstances[i];
         }
       }
@@ -717,22 +717,22 @@
       }
 
       /* Allow reorder */
-      if (typeof this.s.init.allowReorder != 'undefined') {
+      if (typeof this.s.init.allowReorder !== 'undefined') {
         this.s.allowReorder = this.s.init.allowReorder;
       }
 
       /* Allow resize */
-      if (typeof this.s.init.allowResize != 'undefined') {
+      if (typeof this.s.init.allowResize !== 'undefined') {
         this.s.allowResize = this.s.init.allowResize;
       }
 
       /* Allow header double click */
-      if (typeof this.s.init.allowHeaderDoubleClick != 'undefined') {
+      if (typeof this.s.init.allowHeaderDoubleClick !== 'undefined') {
         this.s.allowHeaderDoubleClick = this.s.init.allowHeaderDoubleClick;
       }
 
       /* Allow header contextmenu */
-      if (typeof this.s.init.headerContextMenu == 'function') {
+      if (typeof this.s.init.headerContextMenu === 'function') {
         this.s.headerContextMenu = this.s.init.headerContextMenu;
       }
       else if (this.s.init.headerContextMenu) {
@@ -742,27 +742,27 @@
         this.s.headerContextMenu = false;
       }
 
-      if (typeof this.s.init.minResizeWidth != 'undefined') {
+      if (typeof this.s.init.minResizeWidth !== 'undefined') {
         this.s.minResizeWidth = this.s.init.minResizeWidth;
       }
 
-      if (typeof this.s.init.bResizeTable != 'undefined') {
+      if (typeof this.s.init.bResizeTable !== 'undefined') {
         this.s.bResizeTable = this.s.init.bResizeTable;
       }
 
-      if (typeof this.s.init.bResizeTableWrapper != 'undefined') {
+      if (typeof this.s.init.bResizeTableWrapper !== 'undefined') {
         this.s.bResizeTableWrapper = this.s.init.bResizeTableWrapper;
       }
 
-      if (typeof this.s.init.bTruncateHeaders != 'undefined') {
+      if (typeof this.s.init.bTruncateHeaders !== 'undefined') {
         this.s.bTruncateHeaders = this.s.init.bTruncateHeaders;
       }
 
-      if (typeof this.s.init.bAddFixed != 'undefined') {
+      if (typeof this.s.init.bAddFixed !== 'undefined') {
         this.s.bAddFixed = this.s.init.bAddFixed;
       }
 
-      if (typeof this.s.init.fnResizeTableCallback == 'function') {
+      if (typeof this.s.init.fnResizeTableCallback === 'function') {
         this.s.fnResizeTableCallback = this.s.init.fnResizeTableCallback;
       }
 
@@ -788,15 +788,15 @@
       }
 
       /* State loading, overrides the column order given */
-      if (this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
-        this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length) {
+      if (this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder !== 'undefined' &&
+        this.s.dt.oLoadedState.ColReorder.length === this.s.dt.aoColumns.length) {
         aiOrder = this.s.dt.oLoadedState.ColReorder;
       }
 
       /* Load Column Sizes */
       var asSizes = null;
-      if (this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColSizes != 'undefined' &&
-        this.s.dt.oLoadedState.ColSizes.length == this.s.dt.aoColumns.length) {
+      if (this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColSizes !== 'undefined' &&
+        this.s.dt.oLoadedState.ColSizes.length === this.s.dt.aoColumns.length) {
         asSizes = this.s.dt.oLoadedState.ColSizes;
       }
 
@@ -917,7 +917,7 @@
      *  @private
      */
     "_fnOrderColumns": function (a) {
-      if (a.length != this.s.dt.aoColumns.length) {
+      if (a.length !== this.s.dt.aoColumns.length) {
         this.s.dt.oInstance.oApi._fnLog(this.s.dt, 1, "ColReorder - array reorder does not " +
           "match known number of columns. Skipping.");
         return;
@@ -925,7 +925,7 @@
 
       for (var i = 0, iLen = a.length; i < iLen; i++) {
         var currIndex = $.inArray(i, a);
-        if (i != currIndex) {
+        if (i !== currIndex) {
           /* Reorder our switching array */
           fnArraySwitch(a, currIndex, i);
 
@@ -1007,7 +1007,7 @@
           var nTable = that.s.dt.nTable;
           if (that.dom.drag === null && that.dom.resize === null) {
             /* Store information about the mouse position */
-            var nThTarget = e.target.nodeName == "TH" ? e.target : $(e.target).parents('TH')[0];
+            var nThTarget = e.target.nodeName === "TH" ? e.target : $(e.target).parents('TH')[0];
             var offset = $(nThTarget).offset();
             var nLength = $(nThTarget).innerWidth();
 
@@ -1124,13 +1124,13 @@
       var that = this;
       var target, offset, idx, nThNext, nThPrev;
       /* are we resizing a column ? */
-      if ($(nTh).css('cursor') == 'col-resize') {
+      if ($(nTh).css('cursor') === 'col-resize') {
         // are we at the right or left?
         this.s.mouse.startX = e.pageX;
         this.s.tableWidth = $(nTh).closest("table").width();
 
         // If we are at the left end, we expand the previous column
-        if (this.dom.resizeCol == "left") {
+        if (this.dom.resizeCol === "left") {
           nThPrev = $(nTh).prev();
           this.s.mouse.startWidth = $(nThPrev).outerWidth();
           this.s.mouse.resizeElem = $(nThPrev);
@@ -1259,7 +1259,7 @@
             //Since some columns might have been hidden, find the correct one to resize in the table's body
             var currentColumnIndex;
             visibleColumnIndex = -1;
-            for (currentColumnIndex = -1; currentColumnIndex < this.s.dt.aoColumns.length - 1 && currentColumnIndex != colResized; currentColumnIndex++) {
+            for (currentColumnIndex = -1; currentColumnIndex < this.s.dt.aoColumns.length - 1 && currentColumnIndex !== colResized; currentColumnIndex++) {
               if (this.s.dt.aoColumns[currentColumnIndex + 1].bVisible)
                 visibleColumnIndex++;
             }
@@ -1486,7 +1486,7 @@
         var scrollXEnabled;
         var resizeCol = this.dom.resizeCol;
         /*
-         if (resizeCol == 'right') {
+         if (resizeCol === 'right') {
          colResized++;
          }
          */
@@ -1574,7 +1574,7 @@
          * position is just to it's immediate left or right, so we only incremement the counter for
          * other columns
          */
-        if (i != this.s.mouse.fromIndex) {
+        if (i !== this.s.mouse.fromIndex) {
           iToPoint++;
         }
 
@@ -1854,7 +1854,7 @@
    */
   ColReorder.fnReset = function (oTable) {
     for (var i = 0, iLen = ColReorder.aoInstances.length; i < iLen; i++) {
-      if (ColReorder.aoInstances[i].s.dt.oInstance == oTable) {
+      if (ColReorder.aoInstances[i].s.dt.oInstance === oTable) {
         ColReorder.aoInstances[i].fnReset();
       }
     }
@@ -1889,8 +1889,8 @@
   /*
    * Register a new feature with DataTables
    */
-  if (typeof $.fn.dataTable == "function" &&
-    typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
+  if (typeof $.fn.dataTable === "function" &&
+    typeof $.fn.dataTableExt.fnVersionCheck === "function" &&
     $.fn.dataTableExt.fnVersionCheck('1.9.3')) {
     $.fn.dataTableExt.aoFeatures.push({
       "fnInit": function (settings) {

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -527,7 +527,7 @@
     ColReorder.aoInstances.push(this);
 
 
-    var tableElement = $(this.s.dt.nTable)
+    var tableElement = $(this.s.dt.nTable);
 
     if (this.s.bResizeTableWrapper) {
       tableElement.width(tableElement.width());
@@ -1292,7 +1292,8 @@
 
         if (this.s.bTruncateHeaders) {
           var sortInterceptor = $(nTh).find("div.DataTables_sort_interceptor");
-          var newInterceptorWidth = newWidth - ($(nTh).innerWidth() - $(nTh).width());
+          var sortWrapper
+          var newInterceptorWidth = newWidth - this._fnColumnPaddingWidth(nTh);
           if (newInterceptorWidth < this.s.minResizeWidth) {
             newInterceptorWidth = this.s.minResizeWidth;
           }
@@ -1405,6 +1406,24 @@
           this._fnRegions();
         }
       }
+    },
+
+    /**
+     * Finish off the mouse drag and insert the column where needed
+     *  @method  _fnColumnPaddingWidth
+     *  @param   column
+     *  @returns int
+     *  @private
+     */
+    "_fnColumnPaddingWidth": function(column) {
+      var findPadding = function(element) {
+        return $(element).innerWidth() - $(element).width();
+      }
+      var columnPadding = findPadding(column);
+
+      var sortWrapperPadding= findPadding($(column).find(".DataTables_sort_wrapper"));
+
+      return columnPadding + sortWrapperPadding;
     },
 
 

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -1294,7 +1294,8 @@
           var sortInterceptor = $(nTh).find("div.DataTables_sort_interceptor");
           var newInterceptorWidth = newWidth - this._fnColumnPaddingWidth(nTh);
           if (newInterceptorWidth < this.s.minResizeWidth) {
-            newInterceptorWidth = this.s.minResizeWidth;
+            // need it to be just above the min width, or else the truncate fails
+            newInterceptorWidth = this.s.minResizeWidth + 1;
           }
           sortInterceptor.css({ 'max-width': newInterceptorWidth });
         }
@@ -1376,7 +1377,7 @@
      */
     "_fnColumnPaddingWidth": function(column) {
       var findPadding = function(element) {
-        return $(element).innerWidth() - $(element).width();
+        return $(element).outerWidth() - $(element).width();
       }
       var columnPadding = findPadding(column);
 

--- a/src/plugins/data_table/dataTables.colReorder.js
+++ b/src/plugins/data_table/dataTables.colReorder.js
@@ -1121,7 +1121,6 @@
      *  @private
      */
     "_fnMouseDown": function (e, nTh, i) {
-      // TODO: ajacobs check if this is allowing us to resize bulk actions
       var that = this;
       var target, offset, idx, nThNext, nThPrev;
       /* are we resizing a column ? */

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -62,7 +62,7 @@ var LocalDataTable = (function() {
       return this;
     },
 
-    renderColumnrenderColumn: function(id) {
+    renderColumn: function(id) {
       var config = this._columnManager.columnConfigForId(id);
       if (!config) {
         throw new Error("column not found");
@@ -126,7 +126,7 @@ var LocalDataTable = (function() {
       _.each(columns, this.columnRequired, this);
       this._columnManager.visibility.set(columns);
       _.each(columns, function(state, attr) {
-        state && this.(attr);
+        state && this.renderColumn(attr);
       }, this);
     },
 
@@ -238,7 +238,6 @@ var LocalDataTable = (function() {
           self._onColumnReorder();
         },
         bAddFixed: false,
-        //bResizeTable: false,
         bResizeTableWrapper: false,
         allowHeaderDoubleClick: false,
         allowResize: self.resizableColumns,

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -226,6 +226,11 @@ var LocalDataTable = (function() {
       this._onColumnFilter();
     },
 
+    columnElements: function(selector) {
+      var selectorString = selector || "";
+      return this.$("table").find("thead tr th" + selectorString);
+    },
+
     // Private APIs
 
     _enableReorderableColumns: function() {
@@ -345,11 +350,6 @@ var LocalDataTable = (function() {
 
         this._columnManager.columnsReordered();
       }
-    },
-
-    _columnElements: function(selector) {
-      var selectorString = selector || "";
-      return this.$("table").find("thead tr th" + selectorString);
     },
 
     _allMatchingModels : function() {

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -62,7 +62,7 @@ var LocalDataTable = (function() {
       return this;
     },
 
-    renderColumn: function(id) {
+    renderColumnrenderColumn: function(id) {
       var config = this._columnManager.columnConfigForId(id);
       if (!config) {
         throw new Error("column not found");
@@ -126,7 +126,7 @@ var LocalDataTable = (function() {
       _.each(columns, this.columnRequired, this);
       this._columnManager.visibility.set(columns);
       _.each(columns, function(state, attr) {
-        state && this.renderColumn(attr);
+        state && this.(attr);
       }, this);
     },
 
@@ -238,6 +238,7 @@ var LocalDataTable = (function() {
           self._onColumnReorder();
         },
         bAddFixed: false,
+        //bResizeTable: false,
         bResizeTableWrapper: false,
         allowHeaderDoubleClick: false,
         allowResize: self.resizableColumns,

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -347,8 +347,9 @@ var LocalDataTable = (function() {
       }
     },
 
-    _columnElements: function() {
-      return this.$("table").find("thead tr th");
+    _columnElements: function(selector) {
+      var selectorString = selector || "";
+      return this.$("table").find("thead tr th" + selectorString);
     },
 
     _allMatchingModels : function() {

--- a/src/plugins/data_table/data_table.js
+++ b/src/plugins/data_table/data_table.js
@@ -347,6 +347,10 @@ var LocalDataTable = (function() {
       }
     },
 
+    _columnElements: function() {
+      return this.$("table").find("thead tr th");
+    },
+
     _allMatchingModels : function() {
       // returns all models matching the current filter criteria, regardless of pagination
       // since we are using deferred rendering, the dataTable.$ and dataTable._ methods don't return all


### PR DESCRIPTION
@nburwell 

https://ringrevenue.atlassian.net/browse/WEB-2960

Mind giving this a review? Might be beneficial to get this reviewed so I can bump the version on this branch for QA

Includes the following:

1.  `bTruncateHeaders` flag that is defaulted to true
2. Truncate headers when `bTruncateHeaders` flag is enabled
3. Scroll table when resizing columns