### PR TITLE
1807/eb/web 3741 update all management page urls with each pagination view

### DIFF
--- a/examples_server/examples/data_table/server_side/data_table.js
+++ b/examples_server/examples/data_table/server_side/data_table.js
@@ -93,6 +93,7 @@ Backdraft.app("TableExample", function(app) {
     render: function() {
       var collection  = new app.Collections.Books();
       var table = new app.Views.BookTable({ collection: collection });
+      this.child("table", table);
       this.$el.html(table.render().$el);
       return this;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backdraft-app",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "Plugin-based UI application framework built on top of and extending Backbone to create single page apps",
   "files": [
     "src/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backdraft-app",
-  "version": "1.0.1-beta.1",
+  "version": "1.1.0-beta.1",
   "description": "Plugin-based UI application framework built on top of and extending Backbone to create single page apps",
   "files": [
     "src/",

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -387,7 +387,6 @@ describe("DataTable Plugin", function() {
       });
 
       it("should trigger an event when #selectAllVisible is called", function() {
-        history.pushState({}, "pagination", "?page=3");
         var changeSelectSpy = jasmine.createSpy();
         const table = new this.TableClass({ collection: this.collection });
         table.render();

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -170,10 +170,13 @@ describe("DataTable Plugin", function() {
         history.pushState({}, "pagination", "?");
       });
 
-      it("should handle going back", function() {
+      it("should handle going back in browser history", function() {
         table.render();
+        expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
         table.page("next");
+        expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/11 to 20/);
         table.page("next");
+        expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/21 to 30/);
         Backbone.history.navigate("?page=2", { trigger: false, replace: true });
         $(window).trigger('popstate');
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/11 to 20/);
@@ -209,10 +212,17 @@ describe("DataTable Plugin", function() {
         expect(window.location.search).toMatch(/page=1/);
       });
 
-      it("shouldn't get tripped up by other query variables in the url", function() {
+      it("should load into page 1 if page parameter is not an integer", function() {
+        history.pushState({}, "pagination", "?page=three");
+        table.render();
+        expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
+      });
+
+      it("should load correctly with other variables in the url", function() {
         history.pushState({}, "pagination", "?something=awesome&page=3");
         table.render();
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/21 to 30/);
+        expect(window.location.search).toEqual("?something=awesome&page=3");
       });
     });
 

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -167,6 +167,9 @@ describe("DataTable Plugin", function() {
         history.pushState({}, "pagination", "?page=5");
         table.render();
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/41 to 50/);
+        expect(jQuery.fn.dataTable.settings[0]._iDisplayStart).toEqual(10);
+        expect(jQuery.fn.dataTable.settings[0]._iRecordsTotal).toEqual(100);
+        expect(jQuery.fn.dataTable.settings[0]._iRecordsDisplay).toEqual(100);
       });
       it("should store page in url", function() {
         history.pushState({}, "pagination", "?page=1");
@@ -188,6 +191,7 @@ describe("DataTable Plugin", function() {
         table.render();
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
         expect(window.location.search).toMatch(/page=1/);
+
       });
       it("shouldn't get tripped up by other query variables in the url", function() {
         history.pushState({}, "pagination", "?something=awesome&page=3");

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -5,6 +5,7 @@ import { inDom, createRowClass, createLocalDataTableClass } from "../support/spe
 
 import _ from "underscore";
 import $ from "jquery";
+import Backbone from "backbone";
 
 function createDataTableClass(constructorOptions, protoProperties) {
   return createLocalDataTableClass(_.extend({ rowClass: TestRow }, constructorOptions), protoProperties);

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -153,8 +153,7 @@ describe("DataTable Plugin", function() {
     });
 
     describe("local data table pagination history", function() {
-      let data;
-      let table;
+      let data, table;
       beforeEach(function() {
         Backbone.history.start({
           pushState:  true,
@@ -165,10 +164,12 @@ describe("DataTable Plugin", function() {
         table = new TestDataTable({ collection: this.collection });
         this.collection.reset(data);
       });
+
       afterEach(function() {
         Backbone.history.stop();
         history.pushState({}, "pagination", "?");
       });
+
       it("should handle going back", function() {
         table.render();
         table.page("next");
@@ -177,11 +178,13 @@ describe("DataTable Plugin", function() {
         $(window).trigger('popstate');
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/11 to 20/);
       });
+
       it("should load correct page in table from url", function() {
         history.pushState({}, "pagination", "?page=5");
         table.render();
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/41 to 50/);
       });
+
       it("should store page in url", function() {
         history.pushState({}, "pagination", "?page=1");
         table.render();
@@ -192,17 +195,20 @@ describe("DataTable Plugin", function() {
         table.page(7);
         expect(window.location.search).toMatch(/page=8/);
       });
+
       it("should load into page 1 if no page parameter exists", function() {
         history.pushState({}, "pagination", "?");
         table.render();
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
       });
+
       it("should load into page 1 if page parameter is out of bounds", function() {
         history.pushState({}, "pagination", "?page=500");
         table.render();
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
         expect(window.location.search).toMatch(/page=1/);
       });
+
       it("shouldn't get tripped up by other query variables in the url", function() {
         history.pushState({}, "pagination", "?something=awesome&page=3");
         table.render();

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -156,20 +156,31 @@ describe("DataTable Plugin", function() {
       let data;
       let table;
       beforeEach(function() {
+        Backbone.history.start({
+          pushState:  true,
+          hashChange: false,
+          root:       window.location.pathname
+        });
         data = createBulkData();
         table = new TestDataTable({ collection: this.collection });
         this.collection.reset(data);
       });
-      afterAll(function() {
+      afterEach(function() {
+        Backbone.history.stop();
         history.pushState({}, "pagination", "?");
+      });
+      it("should handle going back", function() {
+        table.render();
+        table.page("next");
+        table.page("next");
+        Backbone.history.navigate("?page=2", { trigger: false, replace: true });
+        $(window).trigger('popstate');
+        expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/11 to 20/);
       });
       it("should load correct page in table from url", function() {
         history.pushState({}, "pagination", "?page=5");
         table.render();
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/41 to 50/);
-        expect(jQuery.fn.dataTable.settings[0]._iDisplayStart).toEqual(10);
-        expect(jQuery.fn.dataTable.settings[0]._iRecordsTotal).toEqual(100);
-        expect(jQuery.fn.dataTable.settings[0]._iRecordsDisplay).toEqual(100);
       });
       it("should store page in url", function() {
         history.pushState({}, "pagination", "?page=1");
@@ -191,7 +202,6 @@ describe("DataTable Plugin", function() {
         table.render();
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
         expect(window.location.search).toMatch(/page=1/);
-
       });
       it("shouldn't get tripped up by other query variables in the url", function() {
         history.pushState({}, "pagination", "?something=awesome&page=3");

--- a/spec/data_table/server_side_data_table_spec.js
+++ b/spec/data_table/server_side_data_table_spec.js
@@ -214,14 +214,17 @@ describe("DataTable Plugin", function() {
       history.pushState({}, "pagination", "?");
     });
 
-    it("should handling going back", function() {
+    it("should handling going back in browser history", function() {
       const table = new TestDataTable({ collection: this.collection });
       table.render();
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
       table.page("next");
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/11 to 20/);
       table.page("next");
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/21 to 30/);
       Backbone.history.navigate("?page=2", { trigger: false, replace: true });
       $(window).trigger('popstate');
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
@@ -268,12 +271,21 @@ describe("DataTable Plugin", function() {
       expect(window.location.search).toMatch(/page=500/);
     });
 
-    it("shouldn't get tripped up by other query variables in the url", function() {
+    it("should load into page 1 if page parameter is not an integer", function() {
+      history.pushState({}, "pagination", "?page=three");
+      const table = new TestDataTable({ collection: this.collection });
+      table.render();
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
+    });
+
+    it("should load correctly with other variables in the url", function() {
       history.pushState({}, "pagination", "?something=awesome&page=3");
       const table = new TestDataTable({ collection: this.collection });
       table.render();
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
       expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/21 to 30/);
+      expect(window.location.search).toEqual("?something=awesome&page=3");
     });
   });
 

--- a/spec/data_table/server_side_data_table_spec.js
+++ b/spec/data_table/server_side_data_table_spec.js
@@ -186,6 +186,7 @@ describe("DataTable Plugin", function() {
 
   afterEach(function() {
     jasmine.clock().uninstall();
+    history.pushState({}, "pagination", "?");
   });
 
   beforeEach(function() {
@@ -206,6 +207,63 @@ describe("DataTable Plugin", function() {
     $('.popover').remove();
     Backbone.history.stop();
     jasmine.Ajax.uninstall();
+  });
+
+  describe("server side pagination history", function() {
+    afterEach(function() {
+      history.pushState({}, "pagination", "?");
+    });
+    it("should not ignore iDisplayStart setting on initialization", function() {
+      const table = new TestDataTable({ collection: this.collection });
+      table.render();
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(jQuery.fn.dataTable.settings[0]._iDisplayStart).toEqual(40);
+      expect(jQuery.fn.dataTable.settings[0]._iRecordsTotal).toEqual(100);
+      expect(jQuery.fn.dataTable.settings[0]._iRecordsDisplay).toEqual(100);
+    });
+    it("should load the correct page from url", function() {
+      history.pushState({}, "pagination", "?page=5");
+      const table = new TestDataTable({ collection: this.collection });
+      table.render();
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/41 to 50/);
+    });
+    it("should store page in url", function() {
+      history.pushState({}, "pagination", "?page=1");
+      const table = new TestDataTable({ collection: this.collection });
+      table.render();
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      table.page("next");
+      expect(window.location.search).toMatch(/page=2/);
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      table.page("previous");
+      expect(window.location.search).toMatch(/page=1/);
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      table.page(7);
+      expect(window.location.search).toMatch(/page=8/);
+    });
+    it("should load into page 1 if no page parameter exists", function() {
+      history.pushState({}, "pagination", "?");
+      const table = new TestDataTable({ collection: this.collection });
+      table.render();
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
+    });
+    it("should load into empty table if page parameter is out of bounds", function() {
+      history.pushState({}, "pagination", "?page=500");
+      const table = new TestDataTable({ collection: this.collection });
+      table.render();
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/4,991 to 100/);
+      expect(window.location.search).toMatch(/page=500/);
+    });
+    it("shouldn't get tripped up by other query variables in the url", function() {
+      history.pushState({}, "pagination", "?something=awesome&page=3");
+      const table = new TestDataTable({ collection: this.collection });
+      table.render();
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/21 to 30/);
+    });
   });
 
   describe("server side restrictions", function() {
@@ -548,7 +606,7 @@ describe("DataTable Plugin", function() {
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
       expect(jasmine.Ajax.requests.mostRecent().url).toMatch("/somewhere?");
       expect(table.$("tbody tr").length).toEqual(10);
-      expect(table.$("div.dataTables_info:contains('Showing 1 to 10 of 100 entries')").length).toEqual(1);
+      expect(table.$("div.dataTables_info:contains('Showing 1 to 10 of 100 entries')").length).toEqual(1, table.$("div.dataTables_info").text());
     });
 
     it("should work with a url that is a function", function() {

--- a/spec/data_table/server_side_data_table_spec.js
+++ b/spec/data_table/server_side_data_table_spec.js
@@ -213,6 +213,7 @@ describe("DataTable Plugin", function() {
     afterEach(function() {
       history.pushState({}, "pagination", "?");
     });
+
     it("should handling going back", function() {
       const table = new TestDataTable({ collection: this.collection });
       table.render();
@@ -226,6 +227,7 @@ describe("DataTable Plugin", function() {
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
       expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/11 to 20/);
     });
+
     it("should load the correct page from url", function() {
       history.pushState({}, "pagination", "?page=5");
       const table = new TestDataTable({ collection: this.collection });
@@ -233,6 +235,7 @@ describe("DataTable Plugin", function() {
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
       expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/41 to 50/);
     });
+
     it("should store page in url", function() {
       history.pushState({}, "pagination", "?page=1");
       const table = new TestDataTable({ collection: this.collection });
@@ -247,6 +250,7 @@ describe("DataTable Plugin", function() {
       table.page(7);
       expect(window.location.search).toMatch(/page=8/);
     });
+
     it("should load into page 1 if no page parameter exists", function() {
       history.pushState({}, "pagination", "?");
       const table = new TestDataTable({ collection: this.collection });
@@ -254,6 +258,7 @@ describe("DataTable Plugin", function() {
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
       expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
     });
+
     it("should load into empty table if page parameter is out of bounds", function() {
       history.pushState({}, "pagination", "?page=500");
       const table = new TestDataTable({ collection: this.collection });
@@ -262,6 +267,7 @@ describe("DataTable Plugin", function() {
       expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/4,991 to 100/);
       expect(window.location.search).toMatch(/page=500/);
     });
+
     it("shouldn't get tripped up by other query variables in the url", function() {
       history.pushState({}, "pagination", "?something=awesome&page=3");
       const table = new TestDataTable({ collection: this.collection });

--- a/spec/data_table/server_side_data_table_spec.js
+++ b/spec/data_table/server_side_data_table_spec.js
@@ -213,13 +213,18 @@ describe("DataTable Plugin", function() {
     afterEach(function() {
       history.pushState({}, "pagination", "?");
     });
-    it("should not ignore iDisplayStart setting on initialization", function() {
+    it("should handling going back", function() {
       const table = new TestDataTable({ collection: this.collection });
       table.render();
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
-      expect(jQuery.fn.dataTable.settings[0]._iDisplayStart).toEqual(40);
-      expect(jQuery.fn.dataTable.settings[0]._iRecordsTotal).toEqual(100);
-      expect(jQuery.fn.dataTable.settings[0]._iRecordsDisplay).toEqual(100);
+      table.page("next");
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      table.page("next");
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      Backbone.history.navigate("?page=2", { trigger: false, replace: true });
+      $(window).trigger('popstate');
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/11 to 20/);
     });
     it("should load the correct page from url", function() {
       history.pushState({}, "pagination", "?page=5");

--- a/spec/data_table_plugin_spec.js
+++ b/spec/data_table_plugin_spec.js
@@ -1275,6 +1275,7 @@ describe("DataTable Plugin", function() {
         stubResizeMode(table);
         triggerMouseMoveEvent(table, { mouseX: -10 });
         const endWidth = startWidth - 10;
+        //TODO: Fix this test so it doesn't break after the first time in yarn run dev
         expect(parseInt($('thead th .DataTables_sort_interceptor').css('max-width'))).toEqual(endWidth, "max-width equal to new width of column (startWidth - 10)");
       });
 

--- a/spec/data_table_plugin_spec.js
+++ b/spec/data_table_plugin_spec.js
@@ -1275,7 +1275,7 @@ describe("DataTable Plugin", function() {
         stubResizeMode(table);
         triggerMouseMoveEvent(table, { mouseX: -10 });
         const endWidth = startWidth - 10;
-        //TODO: Fix this test so it doesn't break after the first time in yarn run dev
+        // TODO: Fix this test so it doesn't break after the first time in yarn run dev
         expect(parseInt($('thead th .DataTables_sort_interceptor').css('max-width'))).toEqual(endWidth, "max-width equal to new width of column (startWidth - 10)");
       });
 

--- a/src/data_table/column_config_generator.js
+++ b/src/data_table/column_config_generator.js
@@ -3,8 +3,6 @@ import _ from "underscore";
 import $ from "jquery";
 import "jquery-deparam";
 
-import "jquery-deparam";
-
 import { toCSSClass } from "../utils/css";
 
 class ColumnConfigGenerator {

--- a/src/data_table/column_config_generator.js
+++ b/src/data_table/column_config_generator.js
@@ -1,6 +1,7 @@
 import Backbone from "backbone";
 import _ from "underscore";
 import $ from "jquery";
+import "jquery-deparam";
 
 import "jquery-deparam";
 

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -480,11 +480,7 @@ class LocalDataTable extends View {
   _pageToSearchPage() {
     let pageNumber = this._parseQueryString(window.location.search);
     if (pageNumber >= 0) {
-      if (pageNumber > this.dataTable.fnPagingInfo().iTotalPages) {
-        this.page(0);
-      } else {
-        this.page(this._parseQueryString(window.location.search));
-      }
+      this.page(this._parseQueryString(window.location.search));
     }
   }
 
@@ -535,6 +531,8 @@ class LocalDataTable extends View {
   }
 
   _dataTableConfig() {
+    let displayStart = this._parseQueryString(window.location.search) * this.paginateLength;
+    let recordTotal = displayStart + 10;
     return {
       sDom: this.layout,
       bDeferRender: true,
@@ -546,6 +544,9 @@ class LocalDataTable extends View {
       aoColumns: this._columnManager.dataTableColumnsConfig(),
       aaSorting: this._columnManager.dataTableSortingConfig(),
       fnDrawCallback: this._onDraw,
+      iDisplayStart: displayStart,
+      iRecordsTotal: recordTotal,
+      iRecordsDisplay: recordTotal,
       oLanguage: {
         sEmptyTable: this.emptyText
       }
@@ -582,6 +583,8 @@ class LocalDataTable extends View {
       $('.DataTables_sort_interceptor', this).on("click", event => {
         if (self.lock("sort")) {
           event.stopImmediatePropagation();
+        } else {
+          history.pushState({}, "pagination", self._createSearchString(0));
         }
       });
       // default sort handler for column with index

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -489,21 +489,9 @@ class LocalDataTable extends View {
     var pageString = "page=" + pageNumber;
     if (queryString.startsWith("?")) {
       queryString = queryString.substr(1);
-      let parameters = queryString.split("&");
-      var pageIndex = -1;
-      parameters.forEach(function(param, index, params) {
-        if (param === "page=") {
-          pageIndex = index;
-        }
-      });
-      if (pageIndex === -1) {
-        searchString += pageString;
-      } else {
-        parameters[pageIndex] = pageString;
-        parameters.forEach(function(param) {
-          searchString += param;
-        });
-      }
+      var parameters = $.deparam(queryString);
+      parameters.page = pageNumber;
+      searchString += $.param(parameters);
     } else {
       searchString += pageString;
     }
@@ -511,18 +499,13 @@ class LocalDataTable extends View {
   }
 
   _parseQueryString(search) {
-    var page = 0;
     if (search.startsWith('?')) {
       search = search.substr(1);
     }
-    let parameters = search.split('&');
-    parameters.forEach(function(param) {
-      if (param.match(/page=/)) {
-        page = parseInt(param.substr(5));
-        page--;
-      }
-    });
-    return page;
+    let parameters = $.deparam(search);
+    let page = parseInt(parameters.page) - 1
+    if (isNaN(page)) { return 0; }
+    return parseInt(parameters.page) - 1;
   }
 
   _initBulkHandling() {

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -80,7 +80,7 @@ class LocalDataTable extends View {
     this._triggerChangeSelection();
     this.paginate && this._setupPaginationHistory();
     this.trigger("render");
-    this.paginate && this._afterRender();
+    this._afterRender();
     return this;
   }
 
@@ -478,7 +478,9 @@ class LocalDataTable extends View {
   }
 
   _afterRender() {
-    this._goToPageFromQueryString();
+    if (this.paginate) {
+      this._goToPageFromQueryString();
+    }
   }
 
   _goToPageFromQueryString() {

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -472,6 +472,9 @@ class LocalDataTable extends View {
         history.pushState({}, "pagination", this._createQueryStringWithPageNumber(page + 1));
       }
     });
+    this.dataTable.on("someTrigger", () => {
+      console.log("Hey it worked!");
+    });
     window.onpopstate = () => {
       this._goToPageFromQueryString();
     };

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -558,7 +558,7 @@ class LocalDataTable extends View {
     if (pageIndex < 0) {
       return 0;
     } else {
-      return (this._parsePageNumberFromQueryString() - 1) * this.paginateLength;
+      return pageIndex * this.paginateLength;
     }
   }
 

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -80,6 +80,7 @@ class LocalDataTable extends View {
     this._triggerChangeSelection();
     this.paginate && this._setupPaginationHistory();
     this.trigger("render");
+    this.paginate && this._afterRender();
     return this;
   }
 
@@ -468,20 +469,19 @@ class LocalDataTable extends View {
     this.dataTable.on("page", () => {
       let page = this.dataTable.fnPagingInfo().iPage;
       if (page !== this._parsePageNumberFromQueryString()) {
-        history.pushState({}, "pagination", this._createSearchString(this.dataTable.fnPagingInfo().iPage + 1));
+        history.pushState({}, "pagination", this._createQueryStringWithPageNumber(page + 1));
       }
     });
     window.onpopstate = () => {
-      this._pageToSearchPage();
+      this._goToPageFromQueryString();
     };
-    this.on("render", this._afterRender());
   }
 
   _afterRender() {
-    this._pageToSearchPage();
+    this._goToPageFromQueryString();
   }
 
-  _pageToSearchPage() {
+  _goToPageFromQueryString() {
     let pageNumber = this._parsePageNumberFromQueryString();
     if (pageNumber >= 0) {
       this.page(pageNumber);
@@ -492,7 +492,7 @@ class LocalDataTable extends View {
     return $.deparam(window.location.href.split("?")[1] || "");
   }
 
-  _createSearchString(pageNumber) {
+  _createQueryStringWithPageNumber(pageNumber) {
     let urlParameters = this._urlParameters();
     urlParameters.page = pageNumber;
     return "?" + $.param(urlParameters);
@@ -530,21 +530,21 @@ class LocalDataTable extends View {
 
   _dataTableConfig() {
     let displayStart = this._parsePageNumberFromQueryString() * this.paginateLength;
-    let recordTotal = displayStart + 10;
+    let recordTotal = displayStart + this.paginateLength;
     return {
       sDom: this.layout,
       bDeferRender: true,
       bPaginate: this.paginate,
       aLengthMenu: this.paginateLengthMenu,
       iDisplayLength: this.paginateLength,
+      iDisplayStart: displayStart,
+      iRecordsTotal: recordTotal,
+      iRecordsDisplay: recordTotal,
       bInfo: true,
       fnCreatedRow: this._onRowCreated,
       aoColumns: this._columnManager.dataTableColumnsConfig(),
       aaSorting: this._columnManager.dataTableSortingConfig(),
       fnDrawCallback: this._onDraw,
-      iDisplayStart: displayStart,
-      iRecordsTotal: recordTotal,
-      iRecordsDisplay: recordTotal,
       oLanguage: {
         sEmptyTable: this.emptyText
       }
@@ -582,7 +582,7 @@ class LocalDataTable extends View {
         if (self.lock("sort")) {
           event.stopImmediatePropagation();
         } else {
-          history.pushState({}, "pagination", self._createSearchString(1));
+          history.pushState({}, "pagination", self._createQueryStringWithPageNumber(1));
         }
       });
       // default sort handler for column with index

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -18,7 +18,6 @@ import { extractColumnCSSClass, toColumnCSSClass } from "../utils/css";
 
 import cidMap from "./cid_map";
 import Config from "./config";
-import "jquery-deparam";
 
 class LocalDataTable extends View {
   constructor(options) {
@@ -465,15 +464,19 @@ class LocalDataTable extends View {
     this.dataTable.on("page", this._bulkCheckboxAdjust);
   }
 
+  _setQueryStringPageFromDataTable() {
+    let page = this.dataTable.fnPagingInfo().iPage;
+    if (page !== this._parsePageNumberFromQueryString() - 1) {
+      history.pushState({}, "pagination", this._createQueryStringWithPageNumber(page + 1));
+    }
+  }
+
   _setupPaginationHistory() {
     this.dataTable.on("page", () => {
-      let page = this.dataTable.fnPagingInfo().iPage;
-      if (page !== this._parsePageNumberFromQueryString() - 1) {
-        history.pushState({}, "pagination", this._createQueryStringWithPageNumber(page + 1));
-      }
+      this._setQueryStringPageFromDataTable();
     });
-    this.dataTable.on("someTrigger", () => {
-      console.log("Hey it worked!");
+    this.dataTable.on("pageLengthChange", () => {
+      this._setQueryStringPageFromDataTable();
     });
     window.onpopstate = () => {
       this._goToPageFromQueryString();

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -78,9 +78,8 @@ class LocalDataTable extends View {
     this._enableRowHighlight();
     this.paginate && this._initPaginationHandling();
     this._triggerChangeSelection();
-    this.trigger("render");
     this.paginate && this._setupPaginationHistory();
-    this.paginate && this._pageToSearchPage();
+    this.trigger("render");
     return this;
   }
 
@@ -473,15 +472,13 @@ class LocalDataTable extends View {
       }
     }.bind(this));
     window.onpopstate = () => {
-      this._safePageToSearchPage();
+      this._pageToSearchPage();
     };
+    this.on("render", this._afterRender());
   }
 
-  _safePageToSearchPage() {
-    let pageNumber = this._parseQueryString(window.location.search);
-    if (pageNumber >= 0) {
-      this.page(this._parseQueryString(window.location.search));
-    }
+  _afterRender() {
+    this._pageToSearchPage();
   }
 
   _pageToSearchPage() {

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -468,7 +468,7 @@ class LocalDataTable extends View {
   _setupPaginationHistory() {
     this.dataTable.on("page", () => {
       let page = this.dataTable.fnPagingInfo().iPage;
-      if (page !== this._parsePageNumberFromQueryString()) {
+      if (page !== this._parsePageNumberFromQueryString() - 1) {
         history.pushState({}, "pagination", this._createQueryStringWithPageNumber(page + 1));
       }
     });
@@ -484,7 +484,7 @@ class LocalDataTable extends View {
   }
 
   _goToPageFromQueryString() {
-    let pageNumber = this._parsePageNumberFromQueryString();
+    let pageNumber = this._parsePageNumberFromQueryString() - 1;
     if (pageNumber >= 0) {
       this.page(pageNumber);
     }
@@ -502,9 +502,9 @@ class LocalDataTable extends View {
 
   _parsePageNumberFromQueryString() {
     let parameters = this._urlParameters();
-    let page = parseInt(parameters.page) - 1;
+    let page = parseInt(parameters.page);
     if (isNaN(page)) {
-      return 0;
+      return 1;
     } else {
       return page;
     }
@@ -531,7 +531,7 @@ class LocalDataTable extends View {
   }
 
   _dataTableConfig() {
-    let displayStart = this._parsePageNumberFromQueryString() * this.paginateLength;
+    let displayStart = (this._parsePageNumberFromQueryString() - 1) * this.paginateLength;
     let recordTotal = displayStart + this.paginateLength;
     return {
       sDom: this.layout,

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -473,8 +473,15 @@ class LocalDataTable extends View {
       }
     }.bind(this));
     window.onpopstate = () => {
-      this._pageToSearchPage();
+      this._safePageToSearchPage();
     };
+  }
+
+  _safePageToSearchPage() {
+    let pageNumber = this._parseQueryString(window.location.search);
+    if (pageNumber >= 0) {
+      this.page(this._parseQueryString(window.location.search));
+    }
   }
 
   _pageToSearchPage() {

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -488,14 +488,18 @@ class LocalDataTable extends View {
     }
   }
 
+  _urlParameters() {
+    return $.deparam(window.location.href.split("?")[1] || "");
+  }
+
   _createSearchString(pageNumber) {
-    let urlParameters = $.deparam(window.location.href.split("?")[1] || "");
+    let urlParameters = this._urlParameters();
     urlParameters.page = pageNumber;
     return "?" + $.param(urlParameters);
   }
 
   _parsePageNumberFromQueryString() {
-    let parameters = $.deparam(window.location.href.split("?")[1] || "");
+    let parameters = this._urlParameters();
     let page = parseInt(parameters.page) - 1;
     if (isNaN(page)) {
       return 0;

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -79,8 +79,8 @@ class LocalDataTable extends View {
     this.paginate && this._initPaginationHandling();
     this._triggerChangeSelection();
     this.trigger("render");
-    this._setupPaginationHistory();
-    this._pageToSearchPage();
+    this.paginate && this._setupPaginationHistory();
+    this.paginate && this._pageToSearchPage();
     return this;
   }
 
@@ -466,7 +466,7 @@ class LocalDataTable extends View {
   }
 
   _setupPaginationHistory() {
-    this.dataTable.on("page", function () {
+    this.dataTable.on("page", function() {
       var page = this.dataTable.fnPagingInfo().iPage;
       if (page !== this._parseQueryString(window.location.search)) {
         history.pushState({}, "pagination", this._createSearchString(this.dataTable.fnPagingInfo().iPage));
@@ -480,7 +480,7 @@ class LocalDataTable extends View {
   _pageToSearchPage() {
     let pageNumber = this._parseQueryString(window.location.search);
     if (pageNumber >= 0) {
-      if (pageNumber >= this.dataTable.fnPagingInfo().iTotalPages) {
+      if (pageNumber > this.dataTable.fnPagingInfo().iTotalPages) {
         this.page(0);
       } else {
         this.page(this._parseQueryString(window.location.search));

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -462,23 +462,30 @@ class LocalDataTable extends View {
 
   _initPaginationHandling() {
     this.dataTable.on("page", this._bulkCheckboxAdjust);
-    this.dataTable.on("page", function(e) {
-      history.pushState({}, "pagination", this._createSearchString(this.dataTable.fnPagingInfo().iPage));
-      window.location.hash++;
+    this.dataTable.on("page", function() {
+      var page = this.dataTable.fnPagingInfo().iPage;
+      if (page !== this._parseQueryString(window.location.search)) {
+        history.pushState({}, "pagination", this._createSearchString(this.dataTable.fnPagingInfo().iPage));
+      }
     }.bind(this));
-    // window.onhashchange = () => { this._pageToSearchPage(); };
-    // window.onpopstate = () => { debugger; this._pageToSearchPage(); };
+    window.onpopstate = () => { this._pageToSearchPage(); };
   }
 
   _pageToSearchPage() {
-    if (this._parseQueryString(window.location.search) > 0) {
-      this.page(this._parseQueryString(window.location.search));
+    let pageNumber = this._parseQueryString(window.location.search);
+    if (pageNumber >= 0) {
+      if (pageNumber >= this.dataTable.fnPagingInfo().iTotalPages) {
+        this.page(0);
+      } else {
+        this.page(this._parseQueryString(window.location.search));
+      }
     }
   }
 
   _createSearchString(pageNumber) {
     var queryString = window.location.search;
     var searchString = "?";
+    pageNumber++;
     var pageString = "page=" + pageNumber;
     if (queryString.startsWith("?")) {
       queryString = queryString.substr(1);
@@ -512,6 +519,7 @@ class LocalDataTable extends View {
     parameters.forEach(function(param) {
       if (param.match(/page=/)) {
         page = parseInt(param.substr(5));
+        page--;
       }
     });
     return page;

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -79,6 +79,7 @@ class LocalDataTable extends View {
     this.paginate && this._initPaginationHandling();
     this._triggerChangeSelection();
     this.trigger("render");
+    this._setupPaginationHistory();
     this._pageToSearchPage();
     return this;
   }
@@ -462,13 +463,18 @@ class LocalDataTable extends View {
 
   _initPaginationHandling() {
     this.dataTable.on("page", this._bulkCheckboxAdjust);
-    this.dataTable.on("page", function() {
+  }
+
+  _setupPaginationHistory() {
+    this.dataTable.on("page", function () {
       var page = this.dataTable.fnPagingInfo().iPage;
       if (page !== this._parseQueryString(window.location.search)) {
         history.pushState({}, "pagination", this._createSearchString(this.dataTable.fnPagingInfo().iPage));
       }
     }.bind(this));
-    window.onpopstate = () => { this._pageToSearchPage(); };
+    window.onpopstate = () => {
+      this._pageToSearchPage();
+    };
   }
 
   _pageToSearchPage() {
@@ -487,7 +493,7 @@ class LocalDataTable extends View {
     var searchString = "?";
     pageNumber++;
     var pageString = "page=" + pageNumber;
-    if (queryString.startsWith("?")) {
+    if (queryString[0] === '?') {
       queryString = queryString.substr(1);
       var parameters = $.deparam(queryString);
       parameters.page = pageNumber;
@@ -499,11 +505,11 @@ class LocalDataTable extends View {
   }
 
   _parseQueryString(search) {
-    if (search.startsWith('?')) {
+    if (search[0] === '?') {
       search = search.substr(1);
     }
     let parameters = $.deparam(search);
-    let page = parseInt(parameters.page) - 1
+    let page = parseInt(parameters.page) - 1;
     if (isNaN(page)) { return 0; }
     return parseInt(parameters.page) - 1;
   }

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -531,7 +531,7 @@ class LocalDataTable extends View {
   }
 
   _dataTableConfig() {
-    let displayStart = (this._parsePageNumberFromQueryString() - 1) * this.paginateLength;
+    let displayStart = this._getSafeDisplayStartFromPageNumber();
     let recordTotal = displayStart + this.paginateLength;
     return {
       sDom: this.layout,
@@ -551,6 +551,15 @@ class LocalDataTable extends View {
         sEmptyTable: this.emptyText
       }
     };
+  }
+
+  _getSafeDisplayStartFromPageNumber() {
+    let pageIndex = this._parsePageNumberFromQueryString() - 1;
+    if (pageIndex < 0) {
+      return 0;
+    } else {
+      return (this._parsePageNumberFromQueryString() - 1) * this.paginateLength;
+    }
   }
 
   _triggerChangeSelection(extraData) {

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -465,12 +465,12 @@ class LocalDataTable extends View {
   }
 
   _setupPaginationHistory() {
-    this.dataTable.on("page", function() {
-      var page = this.dataTable.fnPagingInfo().iPage;
-      if (page !== this._parseQueryString(window.location.search)) {
-        history.pushState({}, "pagination", this._createSearchString(this.dataTable.fnPagingInfo().iPage));
+    this.dataTable.on("page", () => {
+      let page = this.dataTable.fnPagingInfo().iPage;
+      if (page !== this._parsePageNumberFromQueryString()) {
+        history.pushState({}, "pagination", this._createSearchString(this.dataTable.fnPagingInfo().iPage + 1));
       }
-    }.bind(this));
+    });
     window.onpopstate = () => {
       this._pageToSearchPage();
     };
@@ -482,36 +482,26 @@ class LocalDataTable extends View {
   }
 
   _pageToSearchPage() {
-    let pageNumber = this._parseQueryString(window.location.search);
+    let pageNumber = this._parsePageNumberFromQueryString();
     if (pageNumber >= 0) {
-      this.page(this._parseQueryString(window.location.search));
+      this.page(pageNumber);
     }
   }
 
   _createSearchString(pageNumber) {
-    var queryString = window.location.search;
-    var searchString = "?";
-    pageNumber++;
-    var pageString = "page=" + pageNumber;
-    if (queryString[0] === '?') {
-      queryString = queryString.substr(1);
-      var parameters = $.deparam(queryString);
-      parameters.page = pageNumber;
-      searchString += $.param(parameters);
-    } else {
-      searchString += pageString;
-    }
-    return searchString;
+    let urlParameters = $.deparam(window.location.href.split("?")[1] || "");
+    urlParameters.page = pageNumber;
+    return "?" + $.param(urlParameters);
   }
 
-  _parseQueryString(search) {
-    if (search[0] === '?') {
-      search = search.substr(1);
-    }
-    let parameters = $.deparam(search);
+  _parsePageNumberFromQueryString() {
+    let parameters = $.deparam(window.location.href.split("?")[1] || "");
     let page = parseInt(parameters.page) - 1;
-    if (isNaN(page)) { return 0; }
-    return parseInt(parameters.page) - 1;
+    if (isNaN(page)) {
+      return 0;
+    } else {
+      return page;
+    }
   }
 
   _initBulkHandling() {
@@ -535,7 +525,7 @@ class LocalDataTable extends View {
   }
 
   _dataTableConfig() {
-    let displayStart = this._parseQueryString(window.location.search) * this.paginateLength;
+    let displayStart = this._parsePageNumberFromQueryString() * this.paginateLength;
     let recordTotal = displayStart + 10;
     return {
       sDom: this.layout,
@@ -588,7 +578,7 @@ class LocalDataTable extends View {
         if (self.lock("sort")) {
           event.stopImmediatePropagation();
         } else {
-          history.pushState({}, "pagination", self._createSearchString(0));
+          history.pushState({}, "pagination", self._createSearchString(1));
         }
       });
       // default sort handler for column with index

--- a/src/data_table/server_side_data_table.js
+++ b/src/data_table/server_side_data_table.js
@@ -319,7 +319,7 @@ class ServerSideDataTable extends LocalDataTable {
 _.extend(ServerSideDataTable.prototype, {
   // overridden and will be handled via the _onDraw callback
   _initPaginationHandling: $.noop,
-
+  _pageToSearchPage: $.noop,
   // overridden and will be handled via the _onDraw callback
   _bulkCheckboxAdjust: $.noop
 });

--- a/src/data_table/server_side_data_table.js
+++ b/src/data_table/server_side_data_table.js
@@ -319,7 +319,8 @@ class ServerSideDataTable extends LocalDataTable {
 _.extend(ServerSideDataTable.prototype, {
   // overridden and will be handled via the _onDraw callback
   _initPaginationHandling: $.noop,
-  _pageToSearchPage: $.noop,
+  // prevent paging to cause double render
+  _afterRender: $.noop,
   // overridden and will be handled via the _onDraw callback
   _bulkCheckboxAdjust: $.noop
 });

--- a/vendor/jquery.dataTables-1.9.4.js
+++ b/vendor/jquery.dataTables-1.9.4.js
@@ -6493,6 +6493,9 @@
 			_fnMap( oSettings, oInit, "oSearch", "oPreviousSearch" );
 			_fnMap( oSettings, oInit, "aoSearchCols", "aoPreSearchCols" );
 			_fnMap( oSettings, oInit, "iDisplayLength", "_iDisplayLength" );
+      _fnMap( oSettings, oInit, "iDisplayStart", "_iDisplayStart" );
+      _fnMap( oSettings, oInit, "iRecordsTotal", "_iRecordsTotal" );
+      _fnMap( oSettings, oInit, "iRecordsDisplay", "_iRecordsDisplay" );
 			_fnMap( oSettings, oInit, "bJQueryUI", "bJUI" );
 			_fnMap( oSettings, oInit, "fnCookieCallback" );
 			_fnMap( oSettings, oInit, "fnStateLoad" );

--- a/vendor/jquery.dataTables-1.9.4.js
+++ b/vendor/jquery.dataTables-1.9.4.js
@@ -6493,9 +6493,6 @@
 			_fnMap( oSettings, oInit, "oSearch", "oPreviousSearch" );
 			_fnMap( oSettings, oInit, "aoSearchCols", "aoPreSearchCols" );
 			_fnMap( oSettings, oInit, "iDisplayLength", "_iDisplayLength" );
-      _fnMap( oSettings, oInit, "iDisplayStart", "_iDisplayStart" );
-      _fnMap( oSettings, oInit, "iRecordsTotal", "_iRecordsTotal" );
-      _fnMap( oSettings, oInit, "iRecordsDisplay", "_iRecordsDisplay" );
 			_fnMap( oSettings, oInit, "bJQueryUI", "bJUI" );
 			_fnMap( oSettings, oInit, "fnCookieCallback" );
 			_fnMap( oSettings, oInit, "fnStateLoad" );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5297,11 +5297,7 @@ strip-json-comments@~2.0.1:
 
 style-guide@Invoca/style-guide:
   version "1.0.0"
-<<<<<<< HEAD
   resolved "https://codeload.github.com/Invoca/style-guide/tar.gz/cd650392d92a330c8de59687564ba5195ef37f6e"
-=======
-  resolved "https://codeload.github.com/Invoca/style-guide/tar.gz/29fe558b0b67213f74f074dc420764af00a2a76b"
->>>>>>> 9316ed6... Add and import jquery-deparam.
   dependencies:
     eslint ">= 4.19.1"
     eslint-config-standard "^11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5297,7 +5297,11 @@ strip-json-comments@~2.0.1:
 
 style-guide@Invoca/style-guide:
   version "1.0.0"
+<<<<<<< HEAD
   resolved "https://codeload.github.com/Invoca/style-guide/tar.gz/cd650392d92a330c8de59687564ba5195ef37f6e"
+=======
+  resolved "https://codeload.github.com/Invoca/style-guide/tar.gz/29fe558b0b67213f74f074dc420764af00a2a76b"
+>>>>>>> 9316ed6... Add and import jquery-deparam.
   dependencies:
     eslint ">= 4.19.1"
     eslint-config-standard "^11.0.0"


### PR DESCRIPTION
Summary:

* Added `jquery-deparam` gem to pass tests.
* Adds logic for pagination which uses a parameter in the url to store/load the page.
* Light refactoring of reused methods in local_data_table_spec.js

**Note**: Test `"should set the max width to the DataTables_sort_interceptor on resize"` fails on the second time you run a test in `yarn run dev`, which seems to indicate a fragile test.