### PR TITLE
Web 4149 add url pagination flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backdraft-app",
-  "version": "1.2.0",
+  "version": "1.2.1-beta.1",
   "description": "Plugin-based UI application framework built on top of and extending Backbone to create single page apps",
   "files": [
     "src/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backdraft-app",
-  "version": "1.2.1-beta.3",
+  "version": "1.2.1",
   "description": "Plugin-based UI application framework built on top of and extending Backbone to create single page apps",
   "files": [
     "src/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backdraft-app",
-  "version": "1.1.0-beta.1",
+  "version": "1.2.0",
   "description": "Plugin-based UI application framework built on top of and extending Backbone to create single page apps",
   "files": [
     "src/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backdraft-app",
-  "version": "1.2.1-beta.1",
+  "version": "1.2.1-beta.2",
   "description": "Plugin-based UI application framework built on top of and extending Backbone to create single page apps",
   "files": [
     "src/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backdraft-app",
-  "version": "1.2.1-beta.2",
+  "version": "1.2.1-beta.3",
   "description": "Plugin-based UI application framework built on top of and extending Backbone to create single page apps",
   "files": [
     "src/",

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -171,22 +171,32 @@ describe("DataTable Plugin", function() {
         history.pushState({}, "pagination", "?");
       });
 
-      it("should not use url pagination if urlPagination is explicitly false via constructor options", function() {
-        history.pushState({}, "pagination", "?");
-        const NoUrlPagingTable = createDataTableClass({ urlPagination: false }, {});
-        table = new NoUrlPagingTable({ collection: this.collection });
-        table.render();
-        table.page("next");
-        expect(window.location.search).not.toMatch(/page=/);
-      });
+      describe("url pagination explicitly false", function() {
+        it("should not use url pagination via constructor options", function() {
+          history.pushState({}, "pagination", "?");
+          const NoUrlPagingTable = createDataTableClass({ urlPagination: false }, {});
+          table = new NoUrlPagingTable({ collection: this.collection });
+          table.render();
+          table.page("next");
+          expect(window.location.search).not.toMatch(/page=/);
+        });
 
-      it("should not use url pagination if urlPagination is explicitly false via prototype properties", function() {
-        history.pushState({}, "pagination", "?");
-        const NoUrlPagingTable = createDataTableClass({}, { urlPagination: false });
-        table = new NoUrlPagingTable({ collection: this.collection });
-        table.render();
-        table.page("next");
-        expect(window.location.search).not.toMatch(/page=/);
+        it("should not use url pagination via prototype properties", function() {
+          history.pushState({}, "pagination", "?");
+          const NoUrlPagingTable = createDataTableClass({}, { urlPagination: false });
+          table = new NoUrlPagingTable({ collection: this.collection });
+          table.render();
+          table.page("next");
+          expect(window.location.search).not.toMatch(/page=/);
+        });
+
+        it("should not load starting page based on url", function() {
+          history.pushState({}, "pagination", "?page=5");
+          const NoUrlPagingTable = createDataTableClass({}, { urlPagination: false });
+          table = new NoUrlPagingTable({ collection: this.collection });
+          table.render();
+          expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
+        });
       });
 
       it("should handle going back in browser history", function() {

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -171,9 +171,18 @@ describe("DataTable Plugin", function() {
         history.pushState({}, "pagination", "?");
       });
 
-      it("should not use url pagination if urlPagination is explicitly false", function() {
+      it("should not use url pagination if urlPagination is explicitly false via constructor options", function() {
         history.pushState({}, "pagination", "?");
         const NoUrlPagingTable = createDataTableClass({ urlPagination: false }, {});
+        table = new NoUrlPagingTable({ collection: this.collection });
+        table.render();
+        table.page("next");
+        expect(window.location.search).not.toMatch(/page=/);
+      });
+
+      it("should not use url pagination if urlPagination is explicitly false via prototype properties", function() {
+        history.pushState({}, "pagination", "?");
+        const NoUrlPagingTable = createDataTableClass({}, { urlPagination: false });
         table = new NoUrlPagingTable({ collection: this.collection });
         table.render();
         table.page("next");

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -171,6 +171,15 @@ describe("DataTable Plugin", function() {
         history.pushState({}, "pagination", "?");
       });
 
+      it("should not use url pagination if urlPagination is explicitly false", function() {
+        history.pushState({}, "pagination", "?");
+        const NoUrlPagingTable = createDataTableClass({ urlPagination: false }, {});
+        table = new NoUrlPagingTable({ collection: this.collection });
+        table.render();
+        table.page("next");
+        expect(window.location.search).not.toMatch(/page=/);
+      });
+
       it("should handle going back in browser history", function() {
         table.render();
         expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);

--- a/spec/data_table/local_data_table_spec.js
+++ b/spec/data_table/local_data_table_spec.js
@@ -197,6 +197,14 @@ describe("DataTable Plugin", function() {
           table.render();
           expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
         });
+
+        it("should not attempt url pagination if pagination is turned off", function() {
+          history.pushState({}, "pagination", "?page=5");
+          const NoUrlPagingTable = createDataTableClass({}, { paginate: false, urlPagination: true });
+          table = new NoUrlPagingTable({ collection: this.collection });
+          table.render();
+          expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
+        });
       });
 
       it("should handle going back in browser history", function() {

--- a/spec/data_table/server_side_data_table_spec.js
+++ b/spec/data_table/server_side_data_table_spec.js
@@ -214,6 +214,23 @@ describe("DataTable Plugin", function() {
       history.pushState({}, "pagination", "?");
     });
 
+    it("should not use url pagination if urlPagination is explicitly false", function() {
+      history.pushState({}, "pagination", "?");
+      const NoUrlPagingTable = createServerSideDataTableClass({
+        rowClass: TestRow,
+        appName: "SillyBilly",
+        urlPagination: false
+      }, {
+        sorting: [['name', 'desc']],
+        filteringEnabled: true,
+        serverSideFiltering: true
+      });
+      const table = new NoUrlPagingTable({ collection: this.collection });
+      table.render();
+      table.page("next");
+      expect(window.location.search).not.toMatch(/page=/);
+    });
+
     it("should handling going back in browser history", function() {
       const table = new TestDataTable({ collection: this.collection });
       table.render();

--- a/spec/data_table/server_side_data_table_spec.js
+++ b/spec/data_table/server_side_data_table_spec.js
@@ -214,42 +214,61 @@ describe("DataTable Plugin", function() {
       history.pushState({}, "pagination", "?");
     });
 
-    it("should not use url pagination if urlPagination is explicitly false via constructor options", function() {
-      history.pushState({}, "pagination", "?");
-      const NoUrlPagingTable = createServerSideDataTableClass({
-        rowClass: TestRow,
-        appName: "SillyBilly",
-        urlPagination: false
-      }, {
-        sorting: [['name', 'desc']],
-        filteringEnabled: true,
-        serverSideFiltering: true
+    describe("url pagination explicitly false", function() {
+      it("should not use url pagination via constructor options", function() {
+        history.pushState({}, "pagination", "?");
+        const NoUrlPagingTable = createServerSideDataTableClass({
+          rowClass: TestRow,
+          appName: "SillyBilly",
+          urlPagination: false
+        }, {
+          sorting: [['name', 'desc']],
+          filteringEnabled: true,
+          serverSideFiltering: true
+        });
+        const table = new NoUrlPagingTable({ collection: this.collection });
+        table.render();
+        jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+        table.page("next");
+        jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+        expect(window.location.search).not.toMatch(/page=/);
       });
-      const table = new NoUrlPagingTable({ collection: this.collection });
-      table.render();
-      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
-      table.page("next");
-      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
-      expect(window.location.search).not.toMatch(/page=/);
-    });
 
-    it("should not use url pagination if urlPagination is explicitly false via prototype properties", function() {
-      history.pushState({}, "pagination", "?");
-      const NoUrlPagingTable = createServerSideDataTableClass({
-        rowClass: TestRow,
-        appName: "SillyBilly"
-      }, {
-        sorting: [['name', 'desc']],
-        filteringEnabled: true,
-        serverSideFiltering: true,
-        urlPagination: false
+      it("should not use url pagination via prototype properties", function() {
+        history.pushState({}, "pagination", "?");
+        const NoUrlPagingTable = createServerSideDataTableClass({
+          rowClass: TestRow,
+          appName: "SillyBilly"
+        }, {
+          sorting: [['name', 'desc']],
+          filteringEnabled: true,
+          serverSideFiltering: true,
+          urlPagination: false
+        });
+        const table = new NoUrlPagingTable({ collection: this.collection });
+        table.render();
+        jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+        table.page("next");
+        jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+        expect(window.location.search).not.toMatch(/page=/);
       });
-      const table = new NoUrlPagingTable({ collection: this.collection });
-      table.render();
-      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
-      table.page("next");
-      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
-      expect(window.location.search).not.toMatch(/page=/);
+
+      it("should not load starting page based on url", function() {
+        history.pushState({}, "pagination", "?page=5");
+        const NoUrlPagingTable = createServerSideDataTableClass({
+          rowClass: TestRow,
+          appName: "SillyBilly"
+        }, {
+          sorting: [['name', 'desc']],
+          filteringEnabled: true,
+          serverSideFiltering: true,
+          urlPagination: false
+        });
+        const table = new NoUrlPagingTable({ collection: this.collection });
+        table.render();
+        jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+        expect(table.$el.find('.dataTables_info')[0].innerText).toMatch(/1 to 10/);
+      });
     });
 
     it("should handling going back in browser history", function() {

--- a/spec/data_table/server_side_data_table_spec.js
+++ b/spec/data_table/server_side_data_table_spec.js
@@ -214,7 +214,7 @@ describe("DataTable Plugin", function() {
       history.pushState({}, "pagination", "?");
     });
 
-    it("should not use url pagination if urlPagination is explicitly false", function() {
+    it("should not use url pagination if urlPagination is explicitly false via constructor options", function() {
       history.pushState({}, "pagination", "?");
       const NoUrlPagingTable = createServerSideDataTableClass({
         rowClass: TestRow,
@@ -227,7 +227,28 @@ describe("DataTable Plugin", function() {
       });
       const table = new NoUrlPagingTable({ collection: this.collection });
       table.render();
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
       table.page("next");
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      expect(window.location.search).not.toMatch(/page=/);
+    });
+
+    it("should not use url pagination if urlPagination is explicitly false via prototype properties", function() {
+      history.pushState({}, "pagination", "?");
+      const NoUrlPagingTable = createServerSideDataTableClass({
+        rowClass: TestRow,
+        appName: "SillyBilly"
+      }, {
+        sorting: [['name', 'desc']],
+        filteringEnabled: true,
+        serverSideFiltering: true,
+        urlPagination: false
+      });
+      const table = new NoUrlPagingTable({ collection: this.collection });
+      table.render();
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
+      table.page("next");
+      jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());
       expect(window.location.search).not.toMatch(/page=/);
     });
 
@@ -257,7 +278,7 @@ describe("DataTable Plugin", function() {
     });
 
     it("should store page in url", function() {
-      history.pushState({}, "pagination", "?page=1");
+      history.pushState({}, "pagination", "?");
       const table = new TestDataTable({ collection: this.collection });
       table.render();
       jasmine.Ajax.requests.mostRecent().response(this.mockResponse.get());

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -489,7 +489,7 @@ class LocalDataTable extends View {
   }
 
   _afterRender() {
-    if (this.paginate) {
+    if (this.paginate && this.urlPagination) {
       this._goToPageFromQueryString();
     }
   }
@@ -542,8 +542,11 @@ class LocalDataTable extends View {
   }
 
   _dataTableConfig() {
-    let displayStart = this._getSafeDisplayStartFromPageNumber();
-    let recordTotal = displayStart + this.paginateLength;
+    let displayStart, recordTotal;
+    if (this.urlPagination) {
+      displayStart = this._getSafeDisplayStartFromPageNumber();
+      recordTotal = displayStart + this.paginateLength;
+    }
     return {
       sDom: this.layout,
       bDeferRender: true,

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -82,7 +82,7 @@ class LocalDataTable extends View {
     this._enableRowHighlight();
     this.paginate && this._initPaginationHandling();
     this._triggerChangeSelection();
-    this.urlPagination && this._setupPaginationHistory();
+    this.paginate && this.urlPagination && this._setupPaginationHistory();
     this.trigger("render");
     this._afterRender();
     return this;

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -29,11 +29,9 @@ class LocalDataTable extends View {
     _.extend(this, _.pick(this.options, ["selectedIds", "paginate"]));
     _.bindAll(this, "_onRowCreated", "_onBulkHeaderClick", "_onBulkRowClick", "_bulkCheckboxAdjust", "_onDraw",
       "_onColumnVisibilityChange", "_onColumnReorder");
-    if (this.options.urlPagination !== undefined) {
-      this.urlPagination = this.options.urlPagination;
-    } else if (this.urlPagination === undefined) {
-      this.urlPagination = true;
-    }
+
+    this._initKeyWithValueOrDefault('urlPagination', this.options.urlPagination, true);
+    this.urlPagination = this.urlPagination && this.paginate;
 
     this.cache = new Cache();
     this.selectionManager = new SelectionManager();
@@ -46,6 +44,16 @@ class LocalDataTable extends View {
     this.listenTo(this.collection, "add", this._onAdd);
     this.listenTo(this.collection, "remove", this._onRemove);
     this.listenTo(this.collection, "reset", this._onReset);
+  }
+
+  _initKeyWithValueOrDefault(key, value, defaultValue) {
+    if (this[key] === undefined) {
+      if (value !== undefined) {
+        this[key] = value;
+      } else {
+        this[key] = defaultValue;
+      }
+    }
   }
 
   availableColumnTypes() {
@@ -82,7 +90,7 @@ class LocalDataTable extends View {
     this._enableRowHighlight();
     this.paginate && this._initPaginationHandling();
     this._triggerChangeSelection();
-    this.paginate && this.urlPagination && this._setupPaginationHistory();
+    this.urlPagination && this._setupPaginationHistory();
     this.trigger("render");
     this._afterRender();
     return this;
@@ -489,7 +497,7 @@ class LocalDataTable extends View {
   }
 
   _afterRender() {
-    if (this.paginate && this.urlPagination) {
+    if (this.urlPagination) {
       this._goToPageFromQueryString();
     }
   }

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -29,6 +29,8 @@ class LocalDataTable extends View {
     _.extend(this, _.pick(this.options, ["selectedIds", "paginate"]));
     _.bindAll(this, "_onRowCreated", "_onBulkHeaderClick", "_onBulkRowClick", "_bulkCheckboxAdjust", "_onDraw",
       "_onColumnVisibilityChange", "_onColumnReorder");
+    var urlPagination = (this.options.urlPagination === undefined);
+    this.urlPagination = this.paginate && urlPagination;
 
     this.cache = new Cache();
     this.selectionManager = new SelectionManager();
@@ -77,7 +79,7 @@ class LocalDataTable extends View {
     this._enableRowHighlight();
     this.paginate && this._initPaginationHandling();
     this._triggerChangeSelection();
-    this.paginate && this._setupPaginationHistory();
+    this.urlPagination && this._setupPaginationHistory();
     this.trigger("render");
     this._afterRender();
     return this;

--- a/src/data_table/local_data_table.js
+++ b/src/data_table/local_data_table.js
@@ -29,8 +29,11 @@ class LocalDataTable extends View {
     _.extend(this, _.pick(this.options, ["selectedIds", "paginate"]));
     _.bindAll(this, "_onRowCreated", "_onBulkHeaderClick", "_onBulkRowClick", "_bulkCheckboxAdjust", "_onDraw",
       "_onColumnVisibilityChange", "_onColumnReorder");
-    var urlPagination = (this.options.urlPagination === undefined);
-    this.urlPagination = this.paginate && urlPagination;
+    if (this.options.urlPagination !== undefined) {
+      this.urlPagination = this.options.urlPagination;
+    } else if (this.urlPagination === undefined) {
+      this.urlPagination = true;
+    }
 
     this.cache = new Cache();
     this.selectionManager = new SelectionManager();


### PR DESCRIPTION
Adding a flag to data tables to allow for toggling of url pagination. This means you can now have a data table that paginates but doesn't necessarily use url pagination to remember it's history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/invoca/backdraft/105)
<!-- Reviewable:end -->
