### PR TITLE
WEB-4461: unescape filter value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backdraft-app",
-  "version": "1.3.1",
+  "version": "1.3.2-beta.0",
   "description": "Plugin-based UI application framework built on top of and extending Backbone to create single page apps",
   "files": [
     "src/",

--- a/src/data_table/filter_menus/list_filter_menu.js
+++ b/src/data_table/filter_menus/list_filter_menu.js
@@ -1,7 +1,15 @@
 import _ from "underscore";
 import BaseFilterMenu from "./base_filter_menu";
+import { htmlDecode } from "../../utils/helpers";
 
 class ListFilterMenu extends BaseFilterMenu {
+  constructor(options) {
+    super(options);
+
+    // filter.options are are HTML-encoded in the backend (API). Must decode them to construct correct filter URL.
+    this.filter.decodedOptions = _.map(this.filter.options, function(value) { return htmlDecode(value); });
+  }
+
   afterRender() {
     const filterArray = JSON.parse(this.parent.table._getFilteringSettings()) || [];
     // if there are filters in the url...
@@ -81,7 +89,7 @@ _.extend(ListFilterMenu.prototype, {
     <div class="filter-text">Show:</div>
     <a class="select-all" href="javascript:;">Select all</a>
     <ul class="filter-menu-list-container">
-      <% _.each(filter.options, function(element, index) { %>
+      <% _.each(filter.decodedOptions, function(element, index) { %>
         <li>
           <label>
             <input class="list list-item-input" type="checkbox" name="<%= attr %>" value="<%= element %>" /> 

--- a/src/data_table/filter_menus/list_filter_menu.js
+++ b/src/data_table/filter_menus/list_filter_menu.js
@@ -43,13 +43,15 @@ class ListFilterMenu extends BaseFilterMenu {
 
   _onInputChange(event) {
     const filterInput = event.target;
+    // NOTE: filterInput.value must be unescaped because "<%=" escapes it (see template below)
+    const filterValue = _.unescape(filterInput.value);
     if (filterInput.checked) {
       this.filter.value = this.filter.value || [];
-      this.filter.value.push(filterInput.value);
+      this.filter.value.push(filterValue);
       this.parentView._toggleIcon(true);
     } else if (this.filter.value) {
       // remove filter from column manager if it is defined
-      const index = this.filter.value.indexOf(filterInput.value);
+      const index = this.filter.value.indexOf(filterValue);
       if (index > -1) {
         this.filter.value.splice(index, 1);
       }
@@ -82,7 +84,7 @@ _.extend(ListFilterMenu.prototype, {
       <% _.each(filter.options, function(element, index) { %>
         <li>
           <label>
-            <input class="list list-item-input" type="checkbox" name="<%= attr %>" value="<%- element %>" /> 
+            <input class="list list-item-input" type="checkbox" name="<%= attr %>" value="<%= element %>" /> 
             <%= element %>
           </label>
         </li>

--- a/src/utils/css.js
+++ b/src/utils/css.js
@@ -1,17 +1,17 @@
 // create a valid CSS class name based on input
 export function toCSSClass(input) {
-  var cssClass = /[^a-zA-Z_0-9-]/g;
+  const cssClass = /[^a-zA-Z_0-9-]/g;
   return input.replace(cssClass, "-").toLowerCase();
-};
+}
 
 // create a data tables column CSS class name based on input
 export function toColumnCSSClass(input) {
   return "column-" + toCSSClass(input);
-};
+}
 
 // extract the column CSS class from a list of classes, returns undefined if not found
 export function extractColumnCSSClass(classNames) {
-  var matches = classNames.match(/(?:^|\s)column-(?:[^\s]+)/);
+  const matches = classNames.match(/(?:^|\s)column-(?:[^\s]+)/);
   if (matches && matches[0]) {
     return matches[0].trim();
   } else {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,0 +1,7 @@
+export function htmlDecode(value) {
+  if (value) {
+    const doc = new DOMParser().parseFromString(value, "text/html");
+    return doc.documentElement.textContent;
+  }
+  return value;
+}


### PR DESCRIPTION
JIRA: https://ringrevenue.atlassian.net/browse/WEB-4461

Our backend HTML-encodes (unfortunately) stuff like column names, and filter options. If these values are used to make API requests without being decoded, the request will fail because an encoded value won't match a raw value in the DB. For example: encode signal name "Duration &gt; 30 sec" won't match the actual signal name "Duration > 30 sec".
Solution is to decode values before using them in requests. For our ListFilterMenu class, HTML-decode values before using them to construct the element.

`htmlDecode` implementation taken from here: https://github.com/Invoca/web/blob/0b0c45317881be4a730bf6960dbb1221543c0a27/client/reporting/views/helpers.js#L226-L232