### PR TITLE
JETS-1428: register backdraft in Backstage (legacy-frontend, deprecated)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backdraft
+  title: Backdraft
+  description: "Plugin-based UI application framework built on Backbone.js (the @invoca/backdraft-app package). Legacy: in maintenance mode since 2019 and being migrated to Titan (Backdraft-to-Titan / Web2Titan). No new development."
+  annotations:
+    github.com/project-slug: Invoca/backdraft
+    backstage.io/source-location: url:https://github.com/Invoca/backdraft/
+spec:
+  type: library
+  lifecycle: deprecated
+  owner: front-end-guild
+  system: legacy-frontend


### PR DESCRIPTION
Adds a `catalog-info.yaml` so `backdraft` appears in the Backstage catalog + ownership graph. It had none.

- `kind: Component`, `type: library`, owner `front-end-guild`
- **`lifecycle: deprecated`** and **`system: legacy-frontend`** — it's been in maintenance mode since 2019 and is being migrated to Titan (Backdraft-to-Titan / Web2Titan). Kept out of `titan-platform` deliberately.

The `legacy-frontend` System is defined in backstage-catalog#43. Validated with `@roadiehq/backstage-entity-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)